### PR TITLE
Fix Kalman filter estimation

### DIFF
--- a/src/algebra.hpp
+++ b/src/algebra.hpp
@@ -216,11 +216,11 @@ namespace hf {
 
   // determinant of matrix
   // Computes determinant of matrix m, returning d
-  void determinant_3x3(float d, float m[3][3])
+  void determinant_3x3(float * d, float m[3][3])
   {
-     d = m[0][0] * (m[1][1]*m[2][2] - m[1][2] * m[2][1]);
-     d -= m[0][1] * (m[1][0]*m[2][2] - m[1][2] * m[2][0]);
-     d += m[0][2] * (m[1][0]*m[2][1] - m[1][1] * m[2][0]);
+     *d = m[0][0] * (m[1][1]*m[2][2] - m[1][2] * m[2][1]);
+     *d -= m[0][1] * (m[1][0]*m[2][2] - m[1][2] * m[2][0]);
+     *d += m[0][2] * (m[1][0]*m[2][1] - m[1][1] * m[2][0]);
   }
 
   // adjoint of matrix
@@ -261,8 +261,8 @@ namespace hf {
   // inverse b
   void invert_3X3(float b[3][3], float a[3][3])
   {
-     double tmp;
-     determinant_3x3(tmp, a);
+     float tmp;
+     determinant_3x3(& tmp, a);
      tmp = 1.0 / (tmp);
      scale_adjoint_3X3(b, tmp, a);
   }

--- a/src/algebra.hpp
+++ b/src/algebra.hpp
@@ -75,9 +75,9 @@ namespace hf {
   }
 
   // Vector dot product
-  void vec_dot_product(float c, float a[3], float b[3])
+  void vec_dot_product(float * c, float a[3], float b[3])
   {
-     c = (a)[0]*(b)[0] + (a)[1]*(b)[1] + (a)[2]*(b)[2];
+     *c = (a)[0]*(b)[0] + (a)[1]*(b)[1] + (a)[2]*(b)[2];
   }
 
   // Vector length

--- a/src/algebra.hpp
+++ b/src/algebra.hpp
@@ -176,17 +176,17 @@ namespace hf {
   // multiply matrix by scalar and add result to another matrix
   void accum_scale_matrix_3x3(float b[3][3], float s, float a[3][3])
   {
-     b[0][0] += (s) * a[0][0];
-     b[0][1] += (s) * a[0][1];
-     b[0][2] += (s) * a[0][2];
+     b[0][0] += s * a[0][0];
+     b[0][1] += s * a[0][1];
+     b[0][2] += s * a[0][2];
 
-     b[1][0] += (s) * a[1][0];
-     b[1][1] += (s) * a[1][1];
-     b[1][2] += (s) * a[1][2];
+     b[1][0] += s * a[1][0];
+     b[1][1] += s * a[1][1];
+     b[1][2] += s * a[1][2];
 
-     b[2][0] += (s) * a[2][0];
-     b[2][1] += (s) * a[2][1];
-     b[2][2] += (s) * a[2][2];
+     b[2][0] += s * a[2][0];
+     b[2][1] += s * a[2][1];
+     b[2][2] += s * a[2][2];
   }
 
   // matrix product
@@ -276,6 +276,10 @@ namespace hf {
     a[1][0] = v[2];
     a[2][0] = -v[1];
     a[2][1] = v[0];
+    // set diagonal to 0
+    a[0][0] = 0.0;
+    a[1][1] = 0.0;
+    a[2][2] = 0.0;
   }
 
   void print_3X3(float mmm[3][3]) {

--- a/src/algebra.hpp
+++ b/src/algebra.hpp
@@ -81,18 +81,18 @@ namespace hf {
   }
 
   // Vector length
-  void vec_length(float len, float a[3])
+  void vec_length(float * len, float a[3])
   {
-     len = (a)[0]*(a)[0] + (a)[1]*(a)[1];
-     len += (a)[2]*(a)[2];
-     len = sqrt (len);
+     float tmp;
+     tmp = a[0]*a[0] + a[1]*a[1]+a[2]*a[2];
+     *len = sqrt(tmp);
   }
 
   // Normalize vector
   void vec_normalize(float a[3])
   {
-     double len;
-     vec_length(len,a);
+     float len;
+     vec_length(& len,a);
      if (len != 0.0) {
         len = 1.0 / len;
         a[0] *= len;
@@ -277,5 +277,27 @@ namespace hf {
     a[2][0] = -v[1];
     a[2][1] = v[0];
   }
+
+  void print_3X3(float mmm[3][3]) {
+   int i,j;
+   printf ("matrix mmm is \n");
+   if (mmm == NULL) {
+      printf (" Null \n");
+   } else {
+      for (i=0; i<3; i++) {
+         for (j=0; j<3; j++) {
+            printf ("%f ", mmm[i][j]);
+         }
+         printf (" \n");
+      }
+   }
+}
+
+void vec_print(float a[3])
+{
+   float len;
+   vec_length(& len, a);
+   printf(" a is %f %f %f length of a is %f \n", (a)[0], (a)[1], (a)[2], len);
+}
 
 } // namespace hf

--- a/src/altitude.hpp
+++ b/src/altitude.hpp
@@ -93,13 +93,11 @@ namespace hf {
           float verticalAccel = kalman.estimate( imu.gyro,
                                                  imu.accel,
                                                  (currentTime-previousTime)/1000.0);
-          Serial.println(verticalAccel);
           complementary.estimate(& estimatedVelocity,
                                  & estimatedAltitude,
                                  baro.getAltitude(),
                                  pastVerticalAccel,
                                  (currentTime-previousTime)/1000.0);
-          Serial.println(estimatedAltitude);
           pastVerticalAccel = verticalAccel;
           previousTime = currentTime;
           return estimatedAltitude;

--- a/src/altitude.hpp
+++ b/src/altitude.hpp
@@ -45,19 +45,20 @@ namespace hf {
       float ca = 0.5;
       // Zero-velocity update acceleration threshold
       float accel_threshold = 0.3;
-      // Estimated vertical acceleration
-      float accel = 0.0;
       // Sampling period
-      float deltat = 0.0;
+      float previousTime = millis();
       // required filters for altitude and vertical velocity estimation
-      KalmanFilter kalman = KalmanFilter();
+      KalmanFilter kalman = KalmanFilter(ca, sigma_gyro, sigma_accel);
       ComplementaryFilter complementary = ComplementaryFilter(sigma_accel, sigma_baro, accel_threshold);
+      // Estimated past vertical acceleration
+      float pastVerticalAccel = 0;
+      // fake calibration
+      int count = 0;
 
     public:
-
       // estimated altitude and vertical velocity
-      float estimatedAltitude;
-      float estimatedVelocity;
+      float estimatedAltitude = 0;
+      float estimatedVelocity = 0;
 
       void init(void)
       {
@@ -68,20 +69,38 @@ namespace hf {
       {
           baro.update(pressure);
           // Calibrate barometer when the drone is resting
-          if (!armed){
+          if (!armed && count < 100){
             baro.calibrate();
+            count++;
             return;
           }
           return;
       }
 
+      void updateAcceleration(float _accel[3])
+      {
+          imu.updateAcceleration(_accel);
+      }
+
+      void updateGyro(float _gyro[3])
+      {
+          imu.updateGyro(_gyro);
+      }
+
       float estimate()
       {
+          float currentTime = millis();
+          float verticalAccel = kalman.estimate( imu.gyro,
+                                                 imu.accel,
+                                                 currentTime-previousTime);
           complementary.estimate(& estimatedVelocity,
                                  & estimatedAltitude,
                                  baro.getAltitude(),
-                                 accel,
-                                 deltat);
+                                 pastVerticalAccel,
+                                 currentTime-previousTime);
+          pastVerticalAccel = verticalAccel;
+          previousTime = currentTime;
+          return estimatedAltitude;
       }
 
   }; // class AltitudeEstimator
@@ -89,9 +108,6 @@ namespace hf {
   class AltitudeHold {
 
     private:
-      // Altitude estimation
-      AltitudeEstimator altitudeEstimator = AltitudeEstimator();
-
       // State variables
       bool holding;
       float referenceAltitude;
@@ -99,6 +115,8 @@ namespace hf {
       float pid;
 
     public:
+      // Altitude estimation
+      AltitudeEstimator altitudeEstimator = AltitudeEstimator();
 
       AltitudeHold()
       {

--- a/src/altitude.hpp
+++ b/src/altitude.hpp
@@ -92,12 +92,14 @@ namespace hf {
           float currentTime = millis();
           float verticalAccel = kalman.estimate( imu.gyro,
                                                  imu.accel,
-                                                 currentTime-previousTime);
+                                                 (currentTime-previousTime)/1000.0);
+          Serial.println(verticalAccel);
           complementary.estimate(& estimatedVelocity,
                                  & estimatedAltitude,
                                  baro.getAltitude(),
                                  pastVerticalAccel,
-                                 currentTime-previousTime);
+                                 (currentTime-previousTime)/1000.0);
+          Serial.println(estimatedAltitude);
           pastVerticalAccel = verticalAccel;
           previousTime = currentTime;
           return estimatedAltitude;

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -34,7 +34,8 @@ namespace hf {
 
             //------------------------------------ Core functionality ----------------------------------------------------
             virtual bool getQuaternion(float quat[4]) = 0;
-            virtual bool getGyrometer(float gyroRates[3]) = 0;
+            // As a quick patch, get also accel values
+            virtual bool getGyrometer(float gyroRates[3], float accelGs[3]) = 0;
             virtual void writeMotor(uint8_t index, float value) = 0;
 
             //------------------------ Support for additional PID controllers --------------------------------------------

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -157,7 +157,6 @@ namespace hf {
             // P.dot(H.T).dot(inv(H.dot(P).dot(H.T) + R))
             getMeasurementCovariance(R);
             matrix_product_3x3(tmp, errorCovariance, H_trans);
-            print_3X3(tmp);
             matrix_product_3x3(tmp2, this->H, tmp);
             accum_scale_matrix_3x3(tmp2, 1.0, R);
             invert_3X3(tmp2_inv, tmp2);
@@ -217,8 +216,8 @@ namespace hf {
           // perform estimation
           predictState(predictedState, gyro, deltat);
           predictErrorCovariance(errorCovariance, gyro, deltat);
-          // The above has been tested
           updateGain(gain, errorCovariance);
+          // The above has been tested
           updateState(updatedState, predictedState, gain, accel);
           updateErrorCovariance(updatedErrorCovariance, errorCovariance, gain);
           // Store required values for next iteration
@@ -228,7 +227,7 @@ namespace hf {
           vec_scale(tmp, 9.81, updatedState);
           vec_diff(a_sensor, accel, tmp);
           vec_copy(this->a_sensor_prev, a_sensor);
-          vec_dot_product(a_earth, a_sensor, updatedState);
+          vec_dot_product(& a_earth, a_sensor, updatedState);
           return a_earth;
         }
 

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -88,7 +88,7 @@ namespace hf {
             skew(skew_matrix, state_prev);
             float tmp[3][3];
             // Compute the prediction covariance matrix
-            scale_matrix_3x3(sigma, pow(sigma_gyro, 2), identity);
+            scale_matrix_3x3(sigma, pow(this->sigma_gyro, 2), identity);
             matrix_product_3x3(tmp, skew_matrix, sigma);
             matrix_product_3x3(covariance, tmp, skew_matrix);
             scale_matrix_3x3(covariance, -pow(deltat, 2), covariance);
@@ -151,7 +151,7 @@ namespace hf {
             // required matrices
             float R[3][3];
             float H_trans[3][3];
-            transpose_matrix_3x3(H_trans, H);
+            transpose_matrix_3x3(H_trans, this->H);
             float tmp[3][3];
             float tmp2[3][3];
             float tmp2_inv[3][3];
@@ -159,7 +159,7 @@ namespace hf {
             // P.dot(H.T).dot(inv(H.dot(P).dot(H.T) + R))
             getMeasurementCovariance(R);
             matrix_product_3x3(tmp, errorCovariance, H_trans);
-            matrix_product_3x3(tmp2, H, tmp);
+            matrix_product_3x3(tmp2, this->H, tmp);
             accum_scale_matrix_3x3(tmp2, 1.0, R);
             invert_3X3(tmp2_inv, tmp2);
             matrix_product_3x3(gain, tmp, tmp2_inv);
@@ -171,11 +171,11 @@ namespace hf {
             float tmp[3];
             float tmp2[3];
             float measurement[3];
-            vec_scale(tmp, ca, a_sensor_prev);
+            vec_scale(tmp, this->ca, this->a_sensor_prev);
             vec_diff(measurement, accel, tmp);
             // update state with measurement
             // predicted_state + K.dot(measurement - H.dot(predicted_state))
-            mat_dot_vec_3x3(tmp, H, predictedState);
+            mat_dot_vec_3x3(tmp, this->H, predictedState);
             vec_diff(tmp, measurement, tmp);
             mat_dot_vec_3x3(tmp2, gain, tmp);
             vec_sum(updatedState, predictedState, tmp2);
@@ -190,7 +190,7 @@ namespace hf {
             float tmp[3][3];
             float tmp2[3][3];
             // update error covariance with measurement
-            matrix_product_3x3(tmp, gain, H);
+            matrix_product_3x3(tmp, gain, this->H);
             matrix_product_3x3(tmp2, tmp, errorCovariance);
             accum_scale_matrix_3x3(identity, -1.0, tmp2);
             copy_matrix_3x3(covariance, tmp2);
@@ -200,9 +200,9 @@ namespace hf {
 
         KalmanFilter(float ca, float sigma_gyro, float sigma_accel)
         {
-            ca = ca;
-            sigma_gyro = sigma_gyro;
-            sigma_accel = sigma_accel;
+            this->ca = ca;
+            this->sigma_gyro = sigma_gyro;
+            this->sigma_accel = sigma_accel;
         }
 
         float estimate(float gyro[3], float accel[3], float deltat)
@@ -216,19 +216,19 @@ namespace hf {
           float tmp[3];
           float a_earth;
           // perform estimation
-          predictState(predictedState, currentState, gyro, deltat);
+          predictState(predictedState, this->currentState, gyro, deltat);
           // The above has been tested
-          predictErrorCovariance(errorCovariance, currentState, gyro, deltat, currErrorCovariance);
+          predictErrorCovariance(errorCovariance, this->currentState, gyro, deltat, this->currErrorCovariance);
           updateGain(gain, errorCovariance);
           updateState(updatedState, predictedState, gain, accel);
           updateErrorCovariance(updatedErrorCovariance, errorCovariance, gain);
           // Store required values for next iteration
-          vec_copy(currentState, updatedState);
-          copy_matrix_3x3(currErrorCovariance, updatedErrorCovariance);
+          vec_copy(this->currentState, updatedState);
+          copy_matrix_3x3(this->currErrorCovariance, updatedErrorCovariance);
           // return vertical acceleration estimate
           vec_scale(tmp, 9.81, updatedState);
           vec_diff(a_sensor, accel, tmp);
-          vec_copy(a_sensor_prev, a_sensor);
+          vec_copy(this->a_sensor_prev, a_sensor);
           vec_dot_product(a_earth, a_sensor, updatedState);
           return a_earth;
         }

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -223,10 +223,8 @@ namespace hf {
           updateErrorCovariance(updatedErrorCovariance, errorCovariance, gain);
           // Store required values for next iteration
           vec_copy(this->currentState, updatedState);
-          vec_print(updatedState);
           copy_matrix_3x3(this->currErrorCovariance, updatedErrorCovariance);
           // return vertical acceleration estimate
-          vec_print(accel);
           vec_scale(tmp, 9.81, updatedState);
           vec_diff(a_sensor, accel, tmp);
           vec_copy(this->a_sensor_prev, a_sensor);

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -144,7 +144,7 @@ namespace hf {
             accum_scale_matrix_3x3(covariance, 1.0, Q);
         }
 
-        void updateGain(float gain[3][3],float errorCovariance[3][3])
+        void updateGain(float gain[3][3], float errorCovariance[3][3])
         {
             // required matrices
             float R[3][3];
@@ -213,6 +213,7 @@ namespace hf {
           float a_sensor[3];
           float tmp[3];
           float a_earth;
+          vec_scale(accel, 9.81, accel); // Scale accel readings since they are measured in gs
           // perform estimation
           predictState(predictedState, gyro, deltat);
           predictErrorCovariance(errorCovariance, gyro, deltat);
@@ -222,9 +223,10 @@ namespace hf {
           updateErrorCovariance(updatedErrorCovariance, errorCovariance, gain);
           // Store required values for next iteration
           vec_copy(this->currentState, updatedState);
+          vec_print(updatedState);
           copy_matrix_3x3(this->currErrorCovariance, updatedErrorCovariance);
           // return vertical acceleration estimate
-          vec_scale(accel, 9.81, accel); // Scale accel readings since they are measured in gs
+          vec_print(accel);
           vec_scale(tmp, 9.81, updatedState);
           vec_diff(a_sensor, accel, tmp);
           vec_copy(this->a_sensor_prev, a_sensor);

--- a/src/filter.hpp
+++ b/src/filter.hpp
@@ -224,6 +224,7 @@ namespace hf {
           vec_copy(this->currentState, updatedState);
           copy_matrix_3x3(this->currErrorCovariance, updatedErrorCovariance);
           // return vertical acceleration estimate
+          vec_scale(accel, 9.81, accel); // Scale accel readings since they are measured in gs
           vec_scale(tmp, 9.81, updatedState);
           vec_diff(a_sensor, accel, tmp);
           vec_copy(this->a_sensor_prev, a_sensor);

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -87,12 +87,15 @@ namespace hf {
                 }
             }
 
+            // As a quick patch, this method also gets accel values
             void checkGyroRates(void)
             {
                 float gyroRates[3];
+                float accelGs[3];
 
-                if (_board->getGyrometer(gyroRates)) {
-
+                if (_board->getGyrometer(gyroRates, accelGs)) {
+                    altitudeHold.altitudeEstimator.updateGyro(gyroRates);
+                    altitudeHold.altitudeEstimator.updateAcceleration(accelGs);
                     // Start with demands from receiver
                     demands_t demands;
                     memcpy(&demands, &_receiver->demands, sizeof(demands_t));
@@ -229,6 +232,7 @@ namespace hf {
                 checkReceiver();
                 checkAccelerometer();
                 checkBarometer();
+                altitudeHold.altitudeEstimator.estimate();
             }
 
     }; // class Hackflight

--- a/src/sensors/imu.hpp
+++ b/src/sensors/imu.hpp
@@ -35,11 +35,11 @@ namespace hf {
             // This variables will store the latest available readings
             // from the gyro and the IMU. Since this class is Hardware
             // independent this values will have to be supplied
-            float accel[3];
-            float gyro[3];
 
         public:
 
+          float gyro[3];
+          float accel[3];
           // Update last known acceleration values and time of the last measure
           void updateAcceleration(float _accel[3])
           {


### PR DESCRIPTION
1. Fix the Kalman filter implementation so that the vertical acceleration is properly estimated. 
2. Add debugging methods in `src/algebra.hpp` to visualize matrices and vectors.
3. Implement a hack to retrieve acceleration readings. **Note**: This is an ugly patch that will have to be modified.
4. To be able to test the algorithm a counter has been implemented to force the end of the baro calibration. **Note**: This will have to be removed in the final implementation.