### PR TITLE
Change receiver channel map

### DIFF
--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -89,12 +89,12 @@ namespace hf {
 
         // channel indices
         enum {
-            CHANNEL_THROTTLE, 
             CHANNEL_ROLL,    
             CHANNEL_PITCH,  
+            CHANNEL_THROTTLE, 
             CHANNEL_YAW,   
-            CHANNEL_AUX1,
-            CHANNEL_AUX2
+            CHANNEL_AUX2,
+            CHANNEL_AUX1
         };
 
         uint8_t _channelMap[6];


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The default channel map used in Hackflight does not match our setup's channel map.

## Current behavior before PR

The channels of the receiver are not properly mapped for our setup.

## Desired behavior after PR is merged

The channels of the receiver are properly mapped for our setup.
