### PR TITLE
Write motor values with analogWrite

### DIFF
--- a/src/boards/butterfly.hpp
+++ b/src/boards/butterfly.hpp
@@ -50,7 +50,7 @@ namespace hf {
             const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
 
             // Min, max PWM values
-            const uint16_t PWM_MIN = 990;
+            const uint16_t PWM_MIN = 1000;
             const uint16_t PWM_MAX = 2000;
 
             // Butterfly board follows Arduino standard for LED pin
@@ -75,9 +75,6 @@ namespace hf {
 
             // Use the MPU9250 in pass-through mode
             MPU9250_Passthru _imu = MPU9250_Passthru(ASCALE, GSCALE, MSCALE, MMODE, SAMPLE_RATE_DIVISOR);
-
-            // Run motor ESCs using standard Servo library
-            Servo _escs[4];
 
        protected:
 
@@ -108,7 +105,7 @@ namespace hf {
 
             void writeMotor(uint8_t index, float value)
             {
-                _escs[index].writeMicroseconds((uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)));
+                analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)) >> 3);
             }
 
             virtual uint32_t getMicroseconds(void) override
@@ -158,8 +155,8 @@ namespace hf {
 
                 // Connect to the ESCs and send them the baseline values
                 for (uint8_t k=0; k<4; ++k) {
-                    _escs[k].attach(MOTOR_PINS[k]);
-                    _escs[k].writeMicroseconds(PWM_MIN);
+                  pinMode(MOTOR_PINS[k], OUTPUT);
+                  analogWrite(MOTOR_PINS[k], PWM_MIN>>3);
                 }
 
                 // Start I^2C


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Using the `Servo` library to write the motor's PWM makes the drone impossible to fly. This is because the frequency used by the library does meet the ESC protocol requirements. This PR intends to fix this by using `analogWrite`.

## Current behavior before PR

The library used to write the PWM values to the motors (`Servo`) does not work a the expected and required frequency.

## Desired behavior after PR is merged

PWM values are written to the motors at the desired frequency. To do so, instead of the `Servo` library the function `analogWrite` is used.
