### PR TITLE
Parametrize Hackflight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## alpha (unreleased)
+
+### Added
+
+* #37 Hackflight Parametrization
+
+### Changed
+
+### Removed
+
+### Fixed

--- a/examples/Bonadrone/Parametrized/Parametrized.ino
+++ b/examples/Bonadrone/Parametrized/Parametrized.ino
@@ -1,0 +1,14 @@
+#include <Arduino.h>
+#include "main.hpp"
+
+hf::HackflightWrapper hw;
+
+void setup() {
+  // put your setup code here, to run once:
+  hw.init();
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  hw.update();
+}

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -182,7 +182,12 @@
   "SET_PID_CONSTANTS":
   [{"ID": 224},
    {"comment": "Set the controllers' parameters"},
-   {"RateP": "float"}],
+   {"gyroRollPitchP": "float"},
+   {"gyroRollPitchI": "float"},
+   {"gyroRollPitchD": "float"},
+   {"gyroYawP": "float"},
+   {"gyroYawI": "float"},
+   {"demandsToRate": "float"}],
      
   "SET_POSITIONING_BOARD":
   [{"ID": 225},

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -172,6 +172,21 @@
   "FIRMWARE_VERSION":
   [{"ID": 50},
    {"comment": "Current firmware version"},
-   {"version": "byte"}] 
+   {"version": "byte"}],
+   
+  "SET_MOSQUITO_VERSION":
+  [{"ID": 223},
+   {"comment": "Set the type of Mosquito (90 or 150) being used"},
+   {"version": "byte"}],  
+  
+  "SET_PID_CONSTANTS":
+  [{"ID": 224},
+   {"comment": "Set the controllers' parameters"},
+   {"RateP": "float"}],
+     
+   "SET_POSITIONING_BOARD":
+   [{"ID": 225},
+    {"comment": "Specify whether the positioning board is present or not"},
+    {"hasBoard": "byte"}]
 
 }

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -184,9 +184,9 @@
    {"comment": "Set the controllers' parameters"},
    {"RateP": "float"}],
      
-   "SET_POSITIONING_BOARD":
-   [{"ID": 225},
-    {"comment": "Specify whether the positioning board is present or not"},
-    {"hasBoard": "byte"}]
+  "SET_POSITIONING_BOARD":
+  [{"ID": 225},
+   {"comment": "Specify whether the positioning board is present or not"},
+   {"hasBoard": "byte"}]
 
 }

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -31,7 +31,7 @@
    {"c6": "float"}],
 
   "LOST_SIGNAL": 
-  [{"ID": 223},
+  [{"ID": 226},
    {"comment": "ESP32 lost signal MSP message"}, 
    {"flag": "byte"}],
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -187,7 +187,8 @@
    {"gyroRollPitchD": "float"},
    {"gyroYawP": "float"},
    {"gyroYawI": "float"},
-   {"demandsToRate": "float"}],
+   {"demandsToRate": "float"},
+   {"levelP": "float"}],
      
   "SET_POSITIONING_BOARD":
   [{"ID": 225},

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -188,7 +188,16 @@
    {"gyroYawP": "float"},
    {"gyroYawI": "float"},
    {"demandsToRate": "float"},
-   {"levelP": "float"}],
+   {"levelP": "float"},
+   {"altHoldP": "float"},
+   {"altHoldVelP": "float"},
+   {"altHoldVelI": "float"},
+   {"altHoldVelD": "float"},
+   {"minAltitude": "float"},
+   {"param6": "float"},
+   {"param7": "float"},
+   {"param8": "float"},
+   {"param9": "float"}],
      
   "SET_POSITIONING_BOARD":
   [{"ID": 225},

--- a/extras/parser/msppg.py
+++ b/extras/parser/msppg.py
@@ -274,6 +274,8 @@ class HPP_Emitter(CodeEmitter):
                 for argname in argnames:
                     self.output.write(6*self.indent + ('send%s(%s);\n' % (argtype, argname)))
                 self.output.write(6*self.indent + "serialize8(_checksum);\n")
+            else:
+                self.output.write(6*self.indent + "acknowledgeResponse();\n")
             self.output.write(6*self.indent + '} break;\n\n')
 
         self.output.write(4*self.indent + '}\n')

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -112,6 +112,12 @@ namespace hf {
                 headSerialReply(count*size);
             }
 
+            void acknowledgeResponse(void)
+            {
+                prepareToSend(0, 0);
+                serialize8(_checksum);
+            }
+
             void prepareToSendBytes(uint8_t count)
             {
                 prepareToSend(count, 1);

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -36,13 +36,16 @@ namespace hf {
         public:
 
             static const uint8_t MAXMSG = 255;
+            
+            // Number of EEPROM reserved slots for parameters
+            static const int PARAMETER_SLOTS = 100;
 
         private:
 
             static const int INBUF_SIZE  = 128;
             static const int OUTBUF_SIZE = 128;
 
-            int EEPROMindex = 0;
+            int EEPROMindex = PARAMETER_SLOTS;
             bool incomingMission = false;
 
             typedef enum serialState_t {

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <Wire.h>
+#include <EEPROM.h>
 
 #include <LSM6DSM.h> 
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -279,6 +279,7 @@ namespace hf {
             // Map parameters to EEPROM addresses
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
+            static const uint8_t RATE_PID          = 3;
 
             virtual void handle_SET_ARMED_Request(uint8_t  flag)
             {
@@ -363,12 +364,24 @@ namespace hf {
 
             virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t version) override
             {
-                EEPROM.write(MOSQUITO_VERSION, version);
+                EEPROM.put(MOSQUITO_VERSION, version);
             }
             
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t hasBoard) override
             {
-                EEPROM.write(POSITIONING_BOARD, hasBoard);
+                EEPROM.put(POSITIONING_BOARD, hasBoard);
+            }
+            
+            virtual void handle_SET_PID_CONSTANTS_Request(float gyroRollPitchP,
+                float gyroRollPitchI, float gyroRollPitchD, float gyroYawP,
+                float gyroYawI, float demandsToRate) override
+            {
+                EEPROM.put(RATE_PID, gyroRollPitchP);
+                EEPROM.put(RATE_PID + 1 * sizeof(float), gyroRollPitchI);
+                EEPROM.put(RATE_PID + 2 * sizeof(float), gyroRollPitchD);
+                EEPROM.put(RATE_PID + 3 * sizeof(float), gyroYawP);
+                EEPROM.put(RATE_PID + 4 * sizeof(float), gyroYawI);
+                EEPROM.put(RATE_PID + 5 * sizeof(float), demandsToRate);
             }
 
         public:

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -277,9 +277,12 @@ namespace hf {
         protected:
 
             // Map parameters to EEPROM addresses
+            static const uint8_t GENERAL_CONFIG    = 0;
+            static const uint8_t RATE_PID          = 1;
+            // booleans values are stored as the bits of the byte at address 0
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
-            static const uint8_t RATE_PID          = 2;
+
 
             virtual void handle_SET_ARMED_Request(uint8_t  flag)
             {
@@ -364,12 +367,24 @@ namespace hf {
 
             virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t version) override
             {
-                EEPROM.put(MOSQUITO_VERSION, version);
+                uint8_t config = EEPROM.read(GENERAL_CONFIG);
+                if (version)
+                {
+                  EEPROM.put(GENERAL_CONFIG, config | (1 << MOSQUITO_VERSION));
+                } else {
+                  EEPROM.put(GENERAL_CONFIG, config & ~(1 << MOSQUITO_VERSION));
+                }
             }
             
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t hasBoard) override
             {
-                EEPROM.put(POSITIONING_BOARD, hasBoard);
+                uint8_t config = EEPROM.read(GENERAL_CONFIG);
+                if (hasBoard)
+                {
+                  EEPROM.put(GENERAL_CONFIG, config | (1 << POSITIONING_BOARD));
+                } else {
+                  EEPROM.put(GENERAL_CONFIG, config & ~(1 << POSITIONING_BOARD));
+                }
             }
             
             virtual void handle_SET_PID_CONSTANTS_Request(float gyroRollPitchP,

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -317,7 +317,7 @@ namespace hf {
             
             virtual void handle_CLEAR_EEPROM_Request(uint8_t & code) override
             {
-                for (int i = 0 ; i < EEPROM.length() ; i++) 
+                for (int i = PARAMETER_SLOTS ; i < EEPROM.length() ; i++) 
                 {
                     EEPROM.write(i, 0);
                 }
@@ -396,7 +396,7 @@ namespace hf {
                 _receiver->begin();
                 
                 // Initialize the planner
-                planner.init();
+                planner.init(PARAMETER_SLOTS);
                 // XXX Only for debuging purposes.
                 //planner.printMission();
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -276,7 +276,9 @@ namespace hf {
 
         protected:
 
-
+            // Map parameters to EEPROM addresses
+            static const uint8_t MOSQUITO_VERSION  = 0;
+            static const uint8_t POSITIONING_BOARD = 1;
 
             virtual void handle_SET_ARMED_Request(uint8_t  flag)
             {
@@ -359,6 +361,15 @@ namespace hf {
                 _receiver->_lostSignal = flag;
             }
 
+            virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t version) override
+            {
+                EEPROM.write(MOSQUITO_VERSION, version);
+            }
+            
+            virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t hasBoard) override
+            {
+                EEPROM.write(POSITIONING_BOARD, hasBoard);
+            }
 
         public:
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -278,7 +278,7 @@ namespace hf {
 
             // Map parameters to EEPROM addresses
             static const uint8_t GENERAL_CONFIG    = 0;
-            static const uint8_t RATE_PID          = 1;
+            static const uint8_t PID_CONSTANTS     = 1;
             // booleans values are stored as the bits of the byte at address 0
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
@@ -389,14 +389,16 @@ namespace hf {
             
             virtual void handle_SET_PID_CONSTANTS_Request(float gyroRollPitchP,
                 float gyroRollPitchI, float gyroRollPitchD, float gyroYawP,
-                float gyroYawI, float demandsToRate) override
+                float gyroYawI, float demandsToRate, float levelP) override
             {
-                EEPROM.put(RATE_PID, gyroRollPitchP);
-                EEPROM.put(RATE_PID + 1 * sizeof(float), gyroRollPitchI);
-                EEPROM.put(RATE_PID + 2 * sizeof(float), gyroRollPitchD);
-                EEPROM.put(RATE_PID + 3 * sizeof(float), gyroYawP);
-                EEPROM.put(RATE_PID + 4 * sizeof(float), gyroYawI);
-                EEPROM.put(RATE_PID + 5 * sizeof(float), demandsToRate);
+                EEPROM.put(PID_CONSTANTS, gyroRollPitchP);
+                EEPROM.put(PID_CONSTANTS + 1 * sizeof(float), gyroRollPitchI);
+                EEPROM.put(PID_CONSTANTS + 2 * sizeof(float), gyroRollPitchD);
+                EEPROM.put(PID_CONSTANTS + 3 * sizeof(float), gyroYawP);
+                EEPROM.put(PID_CONSTANTS + 4 * sizeof(float), gyroYawI);
+                EEPROM.put(PID_CONSTANTS + 5 * sizeof(float), demandsToRate);
+                EEPROM.put(PID_CONSTANTS + 6 * sizeof(float), levelP);
+                
             }
 
         public:

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -389,7 +389,10 @@ namespace hf {
             
             virtual void handle_SET_PID_CONSTANTS_Request(float gyroRollPitchP,
                 float gyroRollPitchI, float gyroRollPitchD, float gyroYawP,
-                float gyroYawI, float demandsToRate, float levelP) override
+                float gyroYawI, float demandsToRate, float levelP,
+                float altHoldP, float altHoldVelP, float altHoldVelI, float altHoldVelD,
+                float minAltitude, float param6, float param7,
+                float param8, float param9) override
             {
                 EEPROM.put(PID_CONSTANTS, gyroRollPitchP);
                 EEPROM.put(PID_CONSTANTS + 1 * sizeof(float), gyroRollPitchI);
@@ -398,6 +401,11 @@ namespace hf {
                 EEPROM.put(PID_CONSTANTS + 4 * sizeof(float), gyroYawI);
                 EEPROM.put(PID_CONSTANTS + 5 * sizeof(float), demandsToRate);
                 EEPROM.put(PID_CONSTANTS + 6 * sizeof(float), levelP);
+                EEPROM.put(PID_CONSTANTS + 7 * sizeof(float), altHoldP);
+                EEPROM.put(PID_CONSTANTS + 8 * sizeof(float), altHoldVelP);
+                EEPROM.put(PID_CONSTANTS + 9 * sizeof(float), altHoldVelI);
+                EEPROM.put(PID_CONSTANTS + 10 * sizeof(float), altHoldVelD);
+                EEPROM.put(PID_CONSTANTS + 11 * sizeof(float), minAltitude);
                 
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -279,7 +279,7 @@ namespace hf {
             // Map parameters to EEPROM addresses
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
-            static const uint8_t RATE_PID          = 3;
+            static const uint8_t RATE_PID          = 2;
 
             virtual void handle_SET_ARMED_Request(uint8_t  flag)
             {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -55,11 +55,8 @@ namespace hf {
               // Params
               bool hasPositioningBoard = false;
               bool isMosquito90 = false;
-          
-              // Map parameters to EEPROM addresses
-              static const uint8_t MOSQUITO_VERSION  = 0;
-              static const uint8_t POSITIONING_BOARD = 1;
-                            
+
+
               // Required objects to run Hackflight 
               hf::Hackflight h;
               hf::MixerQuadX mixer;
@@ -78,6 +75,9 @@ namespace hf {
                   
               void loadParameters(void)
               {
+                  // Parameter are currently defined in Hackflight because is
+                  // the one in charge of serial communications. Hence, MSP
+                  // message handlers are defined there.
                   isMosquito90 = bool(EEPROM.read(MOSQUITO_VERSION));
                   hasPositioningBoard = bool(EEPROM.read(POSITIONING_BOARD));
               }

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -68,17 +68,6 @@ namespace hf {
               hf::Hackflight h;
               hf::MixerQuadX mixer;
               hf::SBUS_Receiver rc = hf::SBUS_Receiver(CHANNEL_MAP, SERIAL_SBUS, &SBUS_SERIAL);
-              
-              // Controllers
-              hf::Rate ratePid = hf::Rate(
-                _gyroRollPitchP,
-                _gyroRollPitchI,
-                _gyroRollPitchD,
-                _gyroYawP,
-                _gyroYawI,
-                _demandsToRate);
-
-              hf::Level level = hf::Level(0.30f);  // Pitch Level P
                   
               void loadParameters(void)
               {
@@ -113,6 +102,17 @@ namespace hf {
                 rc.setTrimRoll(-0.0030506f);
                 rc.setTrimPitch(-0.0372178f);
                 rc.setTrimYaw(-0.0384381f);
+
+                // Instantiate controllers after loading parameters
+                hf::Rate ratePid = hf::Rate(
+                  _gyroRollPitchP,
+                  _gyroRollPitchI,
+                  _gyroRollPitchD,
+                  _gyroYawP,
+                  _gyroYawI,
+                  _demandsToRate);
+
+                hf::Level level = hf::Level(0.30f);  // Pitch Level P
 
                 // 0 means the controller will always be active, but by changing
                 // that number it can be linked to a different aux state

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -1,0 +1,132 @@
+/*
+   main.hpp : Bonadrone's hackflight entry point. This file creates a Hackflight
+   instance taking into account the defined parameters stored in the EEPROM and 
+   runs it. It acts as a wrapper that automatically creates the correct Hackflight
+   instance as a function of the stored parameters.  
+
+   Copyright (c) 2018 Juan Gallostra & Simon D. Levy
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MEReceiverHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <EEPROM.h>
+#include "hackflight.hpp"
+
+// Board, receiver and mixer used
+#include "boards/bonadrone.hpp"
+#include "receivers/sbus.hpp"
+#include "mixers/quadx.hpp"
+
+// Additional Sensors
+// (Gyrometer and accelerometer are included by default)
+#include <VL53L1X.h>
+#include "sensors/rangefinders/vl53l1x.hpp"
+#include "sensors/opticalflow.hpp"
+
+// Additional Controllers 
+// (Rate is included by default as it is always required)
+#include "pidcontrollers/level.hpp"
+
+// Change this as needed
+#define SBUS_SERIAL Serial1
+
+static constexpr uint8_t CHANNEL_MAP[6] = {2,0,1,3,5,4};
+
+namespace hf {
+
+    class HackflightWrapper : public Hackflight {
+
+        private:
+
+              // Params
+              bool hasPositioningBoard = false;
+              bool isMosquito90 = false;
+          
+              // Map parameters to EEPROM addresses
+              static const uint8_t MOSQUITO_VERSION  = 0;
+              static const uint8_t POSITIONING_BOARD = 1;
+                            
+              // Required objects to run Hackflight 
+              hf::Hackflight h;
+              hf::MixerQuadX mixer;
+              hf::SBUS_Receiver rc = hf::SBUS_Receiver(CHANNEL_MAP, SERIAL_SBUS, &SBUS_SERIAL);
+              
+              // Controllers
+              hf::Rate ratePid = hf::Rate(
+                  0.06f,  // Gyro Roll/Pitch P
+                  0.01f,  // Gyro Roll/Pitch I
+                  0.00f,  // Gyro Roll/Pitch D
+                  0.06f,  // Gyro yaw P
+                  0.01f,  // Gyro yaw I
+                  5.00f); // Demands to rate
+
+              hf::Level level = hf::Level(0.30f);  // Pitch Level P
+                  
+              void loadParameters(void)
+              {
+                  isMosquito90 = bool(EEPROM.read(MOSQUITO_VERSION));
+                  hasPositioningBoard = bool(EEPROM.read(POSITIONING_BOARD));
+              }
+
+        protected:
+
+
+        public:
+
+            void init()
+            {  
+              
+                loadParameters();
+                // begin the serial port for the ESP32
+                Serial4.begin(115200);
+
+                // Trim receiver via software
+                rc.setTrimRoll(-0.0030506f);
+                rc.setTrimPitch(-0.0372178f);
+                rc.setTrimYaw(-0.0384381f);
+
+                // 0 means the controller will always be active, but by changing
+                // that number it can be linked to a different aux state
+                h.addPidController(&level, 0);
+                
+                if (isMosquito90) {
+                    h.init(new hf::BonadroneBrushed(), &rc, &mixer, &ratePid);
+                } else {
+                    h.init(new hf::BonadroneMultiShot(), &rc, &mixer, &ratePid);
+                }
+                // Add additional sensors
+                if (hasPositioningBoard)
+                {
+                    hf::VL53L1X_Rangefinder rangefinder;
+                    rangefinder.begin();
+                    h.addSensor(&rangefinder);
+                    
+                    hf::OpticalFlow opticalflow;
+                    opticalflow.begin();
+                    h.addSensor(&opticalflow);
+                }
+                
+            } // init
+
+            void update(void)
+            {
+                h.update();
+            } // update 
+
+    }; // class HackflightWrapper
+
+} // namespace

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -62,6 +62,8 @@ namespace hf {
               float _gyroYawP;
               float _gyroYawI;
               float _demandsToRate;
+              // Level Params
+              float _levelP;
 
 
               // Required objects to run Hackflight 
@@ -78,12 +80,13 @@ namespace hf {
                   _isMosquito90 = (config >> MOSQUITO_VERSION) & 1;
                   _hasPositioningBoard = (config >> POSITIONING_BOARD) & 1;
                   // Load Rate PID parameters (each float is 4 bytes)
-                  EEPROM.get(RATE_PID, _gyroRollPitchP);
-                  EEPROM.get(RATE_PID + 1 * sizeof(float), _gyroRollPitchI);
-                  EEPROM.get(RATE_PID + 2 * sizeof(float), _gyroRollPitchD);
-                  EEPROM.get(RATE_PID + 3 * sizeof(float), _gyroYawP);
-                  EEPROM.get(RATE_PID + 4 * sizeof(float), _gyroYawI);
-                  EEPROM.get(RATE_PID + 5 * sizeof(float), _demandsToRate);
+                  EEPROM.get(PID_CONSTANTS, _gyroRollPitchP);
+                  EEPROM.get(PID_CONSTANTS + 1 * sizeof(float), _gyroRollPitchI);
+                  EEPROM.get(PID_CONSTANTS + 2 * sizeof(float), _gyroRollPitchD);
+                  EEPROM.get(PID_CONSTANTS + 3 * sizeof(float), _gyroYawP);
+                  EEPROM.get(PID_CONSTANTS + 4 * sizeof(float), _gyroYawI);
+                  EEPROM.get(PID_CONSTANTS + 5 * sizeof(float), _demandsToRate);
+                  EEPROM.get(PID_CONSTANTS + 6 * sizeof(float), _levelP);
                   
               }
 
@@ -113,7 +116,7 @@ namespace hf {
                   _gyroYawI,
                   _demandsToRate);
 
-                hf::Level level = hf::Level(0.30f);  // Pitch Level P
+                hf::Level level = hf::Level(_levelP);  // Pitch Level P
 
                 // 0 means the controller will always be active, but by changing
                 // that number it can be linked to a different aux state

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -71,11 +71,12 @@ namespace hf {
                   
               void loadParameters(void)
               {
-                  // Parameter are currently defined in Hackflight because is
+                  // Parameters are currently defined in Hackflight because is
                   // the one in charge of serial communications. Hence, MSP
                   // message handlers are defined there.
-                  (bool)EEPROM.get(MOSQUITO_VERSION, _isMosquito90);
-                  (bool)EEPROM.get(POSITIONING_BOARD, _hasPositioningBoard);
+                  uint8_t config = EEPROM.read(GENERAL_CONFIG);
+                  _isMosquito90 = (config >> MOSQUITO_VERSION) & 1;
+                  _hasPositioningBoard = (config >> POSITIONING_BOARD) & 1;
                   // Load Rate PID parameters (each float is 4 bytes)
                   EEPROM.get(RATE_PID, _gyroRollPitchP);
                   EEPROM.get(RATE_PID + 1 * sizeof(float), _gyroRollPitchI);

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -40,6 +40,7 @@
 // Additional Controllers 
 // (Rate is included by default as it is always required)
 #include "pidcontrollers/level.hpp"
+#include "pidcontrollers/althold.hpp"
 
 // Change this as needed
 #define SBUS_SERIAL Serial1
@@ -64,6 +65,12 @@ namespace hf {
               float _demandsToRate;
               // Level Params
               float _levelP;
+              // AltHold params
+              float _altHoldP;
+              float _altHoldVelP;
+              float _altHoldVelI;
+              float _altHoldVelD;
+              float _minAltitude;
 
 
               // Required objects to run Hackflight 
@@ -87,6 +94,11 @@ namespace hf {
                   EEPROM.get(PID_CONSTANTS + 4 * sizeof(float), _gyroYawI);
                   EEPROM.get(PID_CONSTANTS + 5 * sizeof(float), _demandsToRate);
                   EEPROM.get(PID_CONSTANTS + 6 * sizeof(float), _levelP);
+                  EEPROM.put(PID_CONSTANTS + 7 * sizeof(float), _altHoldP);
+                  EEPROM.put(PID_CONSTANTS + 8 * sizeof(float), _altHoldVelP);
+                  EEPROM.put(PID_CONSTANTS + 9 * sizeof(float), _altHoldVelI);
+                  EEPROM.put(PID_CONSTANTS + 10 * sizeof(float), _altHoldVelD);
+                  EEPROM.put(PID_CONSTANTS + 11 * sizeof(float), _minAltitude);
                   
               }
 
@@ -137,6 +149,14 @@ namespace hf {
                     hf::OpticalFlow opticalflow;
                     opticalflow.begin();
                     h.addSensor(&opticalflow);
+                    
+                    hf::AltitudeHold althold = hf::AltitudeHold(
+                        _altHoldP,   // Altitude Hold P -> this will set velTarget to 0
+                        _altHoldVelP,   // Altitude Hold Velocity P
+                        _altHoldVelI,   // Altitude Hold Velocity I
+                        _altHoldVelD,   // Altitude Hold Velocity D
+                        _minAltitude);  // Min altitude
+                    h.addPidController(&althold, 2);
                 }
                 
             } // init

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -130,6 +130,18 @@ namespace hf {
 
                 hf::Level level = hf::Level(_levelP);  // Pitch Level P
 
+                // Add additional sensors
+                if (_hasPositioningBoard)
+                {
+                    hf::AltitudeHold althold = hf::AltitudeHold(
+                        _altHoldP,   // Altitude Hold P -> this will set velTarget to 0
+                        _altHoldVelP,   // Altitude Hold Velocity P
+                        _altHoldVelI,   // Altitude Hold Velocity I
+                        _altHoldVelD,   // Altitude Hold Velocity D
+                        _minAltitude);  // Min altitude
+                    h.addPidController(&althold, 2);
+                }
+
                 // 0 means the controller will always be active, but by changing
                 // that number it can be linked to a different aux state
                 h.addPidController(&level, 0);
@@ -148,15 +160,7 @@ namespace hf {
                     
                     hf::OpticalFlow opticalflow;
                     opticalflow.begin();
-                    h.addSensor(&opticalflow);
-                    
-                    hf::AltitudeHold althold = hf::AltitudeHold(
-                        _altHoldP,   // Altitude Hold P -> this will set velTarget to 0
-                        _altHoldVelP,   // Altitude Hold Velocity P
-                        _altHoldVelI,   // Altitude Hold Velocity I
-                        _altHoldVelD,   // Altitude Hold Velocity D
-                        _minAltitude);  // Min altitude
-                    h.addPidController(&althold, 2);
+                    h.addSensor(&opticalflow);                    
                 }
                 
             } // init

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -665,7 +665,34 @@ namespace hf {
                         float levelP = 0;
                         memcpy(&levelP,  &_inBuf[24], sizeof(float));
 
-                        handle_SET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate, levelP);
+                        float altHoldP = 0;
+                        memcpy(&altHoldP,  &_inBuf[28], sizeof(float));
+
+                        float altHoldVelP = 0;
+                        memcpy(&altHoldVelP,  &_inBuf[32], sizeof(float));
+
+                        float altHoldVelI = 0;
+                        memcpy(&altHoldVelI,  &_inBuf[36], sizeof(float));
+
+                        float altHoldVelD = 0;
+                        memcpy(&altHoldVelD,  &_inBuf[40], sizeof(float));
+
+                        float minAltitude = 0;
+                        memcpy(&minAltitude,  &_inBuf[44], sizeof(float));
+
+                        float param6 = 0;
+                        memcpy(&param6,  &_inBuf[48], sizeof(float));
+
+                        float param7 = 0;
+                        memcpy(&param7,  &_inBuf[52], sizeof(float));
+
+                        float param8 = 0;
+                        memcpy(&param8,  &_inBuf[56], sizeof(float));
+
+                        float param9 = 0;
+                        memcpy(&param9,  &_inBuf[60], sizeof(float));
+
+                        handle_SET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate, levelP, altHoldP, altHoldVelP, altHoldVelI, altHoldVelD, minAltitude, param6, param7, param8, param9);
                         } break;
 
                     case 225:
@@ -1234,7 +1261,7 @@ namespace hf {
                 (void)version;
             }
 
-            virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP)
+            virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
             {
                 (void)gyroRollPitchP;
                 (void)gyroRollPitchI;
@@ -1243,9 +1270,18 @@ namespace hf {
                 (void)gyroYawI;
                 (void)demandsToRate;
                 (void)levelP;
+                (void)altHoldP;
+                (void)altHoldVelP;
+                (void)altHoldVelI;
+                (void)altHoldVelD;
+                (void)minAltitude;
+                (void)param6;
+                (void)param7;
+                (void)param8;
+                (void)param9;
             }
 
-            virtual void handle_SET_PID_CONSTANTS_Data(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP)
+            virtual void handle_SET_PID_CONSTANTS_Data(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
             {
                 (void)gyroRollPitchP;
                 (void)gyroRollPitchI;
@@ -1254,6 +1290,15 @@ namespace hf {
                 (void)gyroYawI;
                 (void)demandsToRate;
                 (void)levelP;
+                (void)altHoldP;
+                (void)altHoldVelP;
+                (void)altHoldVelI;
+                (void)altHoldVelD;
+                (void)minAltitude;
+                (void)param6;
+                (void)param7;
+                (void)param8;
+                (void)param9;
             }
 
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
@@ -2031,12 +2076,12 @@ namespace hf {
                 return 7;
             }
 
-            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP)
+            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 28;
+                bytes[3] = 64;
                 bytes[4] = 224;
 
                 memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
@@ -2046,10 +2091,19 @@ namespace hf {
                 memcpy(&bytes[21], &gyroYawI, sizeof(float));
                 memcpy(&bytes[25], &demandsToRate, sizeof(float));
                 memcpy(&bytes[29], &levelP, sizeof(float));
+                memcpy(&bytes[33], &altHoldP, sizeof(float));
+                memcpy(&bytes[37], &altHoldVelP, sizeof(float));
+                memcpy(&bytes[41], &altHoldVelI, sizeof(float));
+                memcpy(&bytes[45], &altHoldVelD, sizeof(float));
+                memcpy(&bytes[49], &minAltitude, sizeof(float));
+                memcpy(&bytes[53], &param6, sizeof(float));
+                memcpy(&bytes[57], &param7, sizeof(float));
+                memcpy(&bytes[61], &param8, sizeof(float));
+                memcpy(&bytes[65], &param9, sizeof(float));
 
-                bytes[33] = CRC8(&bytes[3], 30);
+                bytes[69] = CRC8(&bytes[3], 66);
 
-                return 34;
+                return 70;
             }
 
             static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -644,10 +644,25 @@ namespace hf {
 
                     case 224:
                     {
-                        float RateP = 0;
-                        memcpy(&RateP,  &_inBuf[0], sizeof(float));
+                        float gyroRollPitchP = 0;
+                        memcpy(&gyroRollPitchP,  &_inBuf[0], sizeof(float));
 
-                        handle_SET_PID_CONSTANTS_Request(RateP);
+                        float gyroRollPitchI = 0;
+                        memcpy(&gyroRollPitchI,  &_inBuf[4], sizeof(float));
+
+                        float gyroRollPitchD = 0;
+                        memcpy(&gyroRollPitchD,  &_inBuf[8], sizeof(float));
+
+                        float gyroYawP = 0;
+                        memcpy(&gyroYawP,  &_inBuf[12], sizeof(float));
+
+                        float gyroYawI = 0;
+                        memcpy(&gyroYawI,  &_inBuf[16], sizeof(float));
+
+                        float demandsToRate = 0;
+                        memcpy(&demandsToRate,  &_inBuf[20], sizeof(float));
+
+                        handle_SET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate);
                         } break;
 
                     case 225:
@@ -1216,14 +1231,24 @@ namespace hf {
                 (void)version;
             }
 
-            virtual void handle_SET_PID_CONSTANTS_Request(float  RateP)
+            virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate)
             {
-                (void)RateP;
+                (void)gyroRollPitchP;
+                (void)gyroRollPitchI;
+                (void)gyroRollPitchD;
+                (void)gyroYawP;
+                (void)gyroYawI;
+                (void)demandsToRate;
             }
 
-            virtual void handle_SET_PID_CONSTANTS_Data(float  RateP)
+            virtual void handle_SET_PID_CONSTANTS_Data(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate)
             {
-                (void)RateP;
+                (void)gyroRollPitchP;
+                (void)gyroRollPitchI;
+                (void)gyroRollPitchD;
+                (void)gyroYawP;
+                (void)gyroYawI;
+                (void)demandsToRate;
             }
 
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
@@ -2001,19 +2026,24 @@ namespace hf {
                 return 7;
             }
 
-            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  RateP)
+            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 4;
+                bytes[3] = 24;
                 bytes[4] = 224;
 
-                memcpy(&bytes[5], &RateP, sizeof(float));
+                memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
+                memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));
+                memcpy(&bytes[13], &gyroRollPitchD, sizeof(float));
+                memcpy(&bytes[17], &gyroYawP, sizeof(float));
+                memcpy(&bytes[21], &gyroYawI, sizeof(float));
+                memcpy(&bytes[25], &demandsToRate, sizeof(float));
 
-                bytes[9] = CRC8(&bytes[3], 6);
+                bytes[29] = CRC8(&bytes[3], 26);
 
-                return 10;
+                return 30;
             }
 
             static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -662,7 +662,10 @@ namespace hf {
                         float demandsToRate = 0;
                         memcpy(&demandsToRate,  &_inBuf[20], sizeof(float));
 
-                        handle_SET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate);
+                        float levelP = 0;
+                        memcpy(&levelP,  &_inBuf[24], sizeof(float));
+
+                        handle_SET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate, levelP);
                         } break;
 
                     case 225:
@@ -1231,7 +1234,7 @@ namespace hf {
                 (void)version;
             }
 
-            virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate)
+            virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP)
             {
                 (void)gyroRollPitchP;
                 (void)gyroRollPitchI;
@@ -1239,9 +1242,10 @@ namespace hf {
                 (void)gyroYawP;
                 (void)gyroYawI;
                 (void)demandsToRate;
+                (void)levelP;
             }
 
-            virtual void handle_SET_PID_CONSTANTS_Data(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate)
+            virtual void handle_SET_PID_CONSTANTS_Data(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP)
             {
                 (void)gyroRollPitchP;
                 (void)gyroRollPitchI;
@@ -1249,6 +1253,7 @@ namespace hf {
                 (void)gyroYawP;
                 (void)gyroYawI;
                 (void)demandsToRate;
+                (void)levelP;
             }
 
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
@@ -2026,12 +2031,12 @@ namespace hf {
                 return 7;
             }
 
-            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate)
+            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 24;
+                bytes[3] = 28;
                 bytes[4] = 224;
 
                 memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
@@ -2040,10 +2045,11 @@ namespace hf {
                 memcpy(&bytes[17], &gyroYawP, sizeof(float));
                 memcpy(&bytes[21], &gyroYawI, sizeof(float));
                 memcpy(&bytes[25], &demandsToRate, sizeof(float));
+                memcpy(&bytes[29], &levelP, sizeof(float));
 
-                bytes[29] = CRC8(&bytes[3], 26);
+                bytes[33] = CRC8(&bytes[3], 30);
 
-                return 30;
+                return 34;
             }
 
             static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -364,7 +364,7 @@ namespace hf {
                         handle_SET_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
                         } break;
 
-                    case 223:
+                    case 226:
                     {
                         uint8_t flag = 0;
                         memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
@@ -1331,7 +1331,7 @@ namespace hf {
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 1;
-                bytes[4] = 223;
+                bytes[4] = 226;
 
                 memcpy(&bytes[5], &flag, sizeof(uint8_t));
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -36,13 +36,16 @@ namespace hf {
         public:
 
             static const uint8_t MAXMSG = 255;
+            
+            // Number of EEPROM reserved slots for parameters
+            static const int PARAMETER_SLOTS = 100;
 
         private:
 
             static const int INBUF_SIZE  = 128;
             static const int OUTBUF_SIZE = 128;
 
-            int EEPROMindex = 0;
+            int EEPROMindex = PARAMETER_SLOTS;
             bool incomingMission = false;
 
             typedef enum serialState_t {

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -631,6 +631,30 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
+                    case 223:
+                    {
+                        uint8_t version = 0;
+                        memcpy(&version,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_MOSQUITO_VERSION_Request(version);
+                        } break;
+
+                    case 224:
+                    {
+                        float RateP = 0;
+                        memcpy(&RateP,  &_inBuf[0], sizeof(float));
+
+                        handle_SET_PID_CONSTANTS_Request(RateP);
+                        } break;
+
+                    case 225:
+                    {
+                        uint8_t hasBoard = 0;
+                        memcpy(&hasBoard,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_POSITIONING_BOARD_Request(hasBoard);
+                        } break;
+
                 }
             }
 
@@ -1177,6 +1201,36 @@ namespace hf {
             virtual void handle_FIRMWARE_VERSION_Data(uint8_t & version)
             {
                 (void)version;
+            }
+
+            virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t  version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_SET_MOSQUITO_VERSION_Data(uint8_t  version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_SET_PID_CONSTANTS_Request(float  RateP)
+            {
+                (void)RateP;
+            }
+
+            virtual void handle_SET_PID_CONSTANTS_Data(float  RateP)
+            {
+                (void)RateP;
+            }
+
+            virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
+            {
+                (void)hasBoard;
+            }
+
+            virtual void handle_SET_POSITIONING_BOARD_Data(uint8_t  hasBoard)
+            {
+                (void)hasBoard;
             }
 
         public:
@@ -1923,6 +1977,51 @@ namespace hf {
                 bytes[4] = 50;
 
                 memcpy(&bytes[5], &version, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_SET_MOSQUITO_VERSION(uint8_t bytes[], uint8_t  version)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 223;
+
+                memcpy(&bytes[5], &version, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  RateP)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 4;
+                bytes[4] = 224;
+
+                memcpy(&bytes[5], &RateP, sizeof(float));
+
+                bytes[9] = CRC8(&bytes[3], 6);
+
+                return 10;
+            }
+
+            static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 225;
+
+                memcpy(&bytes[5], &hasBoard, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -112,6 +112,12 @@ namespace hf {
                 headSerialReply(count*size);
             }
 
+            void acknowledgeResponse(void)
+            {
+                prepareToSend(0, 0);
+                serialize8(_checksum);
+            }
+
             void prepareToSendBytes(uint8_t count)
             {
                 prepareToSend(count, 1);
@@ -362,6 +368,7 @@ namespace hf {
                         memcpy(&c6,  &_inBuf[20], sizeof(float));
 
                         handle_SET_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
+                        acknowledgeResponse();
                         } break;
 
                     case 226:
@@ -370,6 +377,7 @@ namespace hf {
                         memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
 
                         handle_LOST_SIGNAL_Request(flag);
+                        acknowledgeResponse();
                         } break;
 
                     case 122:
@@ -415,6 +423,7 @@ namespace hf {
                         memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
 
                         handle_SET_ARMED_Request(flag);
+                        acknowledgeResponse();
                         } break;
 
                     case 199:
@@ -443,6 +452,7 @@ namespace hf {
                         memcpy(&m4,  &_inBuf[12], sizeof(float));
 
                         handle_SET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
+                        acknowledgeResponse();
                         } break;
 
                     case 124:
@@ -640,6 +650,7 @@ namespace hf {
                         memcpy(&version,  &_inBuf[0], sizeof(uint8_t));
 
                         handle_SET_MOSQUITO_VERSION_Request(version);
+                        acknowledgeResponse();
                         } break;
 
                     case 224:
@@ -693,6 +704,7 @@ namespace hf {
                         memcpy(&param9,  &_inBuf[60], sizeof(float));
 
                         handle_SET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate, levelP, altHoldP, altHoldVelP, altHoldVelI, altHoldVelD, minAltitude, param6, param7, param8, param9);
+                        acknowledgeResponse();
                         } break;
 
                     case 225:
@@ -701,6 +713,7 @@ namespace hf {
                         memcpy(&hasBoard,  &_inBuf[0], sizeof(uint8_t));
 
                         handle_SET_POSITIONING_BOARD_Request(hasBoard);
+                        acknowledgeResponse();
                         } break;
 
                 }

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -62,9 +62,9 @@ namespace hf {
           // the action and takes in to account the position of the previous action 
           float _integralPosition[3] = {0, 0, 0};
                         
-          void loadMission(action_t mission[256])
+          void loadMission(action_t mission[256], int startingAddress)
           {
-              int address = 0;
+              int address = startingAddress;
               int actionIndex = 0;
               int EEPROMlength = EEPROM.length();
               // Although we iterate through the whole EEPROM length the index
@@ -158,10 +158,10 @@ namespace hf {
 
         public:
           
-            void init(void)
+            void init(int startingAddress)
             {
                 _hasMission = false;
-                loadMission(_mission);
+                loadMission(_mission, startingAddress);
                 _currentActionIndex = 0;
                 _currentAction = _mission[_currentActionIndex];
             }

--- a/src/sensors/opticalflow.hpp
+++ b/src/sensors/opticalflow.hpp
@@ -37,7 +37,7 @@ namespace hf {
             static constexpr float UPDATE_PERIOD = .01f;
 
             // Use digital pin 10 for chip select
-            PMW3901 _flowSensor = PMW3901(10);
+            PMW3901 _flowSensor = PMW3901(A4, &SPI1);
 
             // Track elapsed time for periodic readiness
             bool _previousTime = 0;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Parametrize Hackflight.

## Current behavior before PR

An Arduino sketch has to be created where all the parameters (type of board, PID constants, type of receiver, mixer...) are defined when running Hackflight on a BonaDrone board.

As an example see [SBUSAltHold.ino](https://github.com/BonaDrone/Hackflight/blob/master/examples/Bonadrone/SBUSAltHold/SBUSAltHold.ino)

## Desired behavior after PR is merged

Instead of having to create an Arduino sketch for each configuration, a generic routine that loads parameters from the EEPROM will handle the instantiation of Hackflight with the specified parameters.

The Arduino sketch gets reduced to: [Parametrized.ino](https://github.com/BonaDrone/Hackflight/blob/parametrization/examples/Bonadrone/Parametrized/Parametrized.ino)

And all the initialization is delegated to [HackflightWrapper](https://github.com/BonaDrone/Hackflight/blob/parametrization/src/main.hpp)

### Setting parameters

Parameters are specified via MSP messages. There are currently 3 MSP messages used to set parameters:
1. `SET_POSITIONING_BOARD`: message ID is 225 with a payload of 1byte. 0/1 flag indicating whether the positioning board is present or not.
2. `SET_MOSQUITO_VERSION`: message ID is 223 with a payload of 1byte. 0/1 flag indicating the Mosquito version (0 is Mosquito 150 and 1 is Mosquito 90).
3. `SET_PID_CONSTANTS`: message ID is 224 with a payload of 64 bytes (16 floats x 4 bytes each). 16 floats that specify the parameters of the PID controllers.

When one of this messages is received its contents are stored in the appropriate EEPROM addresses. See [BonaDrone's documentation](https://github.com/BonaDrone/documentation/blob/master/README.md) (EEPROM usage chapter) for more details.

### Loading parameters

A new class that acts as a wrapper for Hackflight has been implemented (see `HackflightWrapper` in `main.hpp`). This class reads and decodes EEPROM stored parameters and instantiates the required classes accordingly. After that  Hackflight is initialized and ran as before.  

--
I confirm I have tested this PR thoroughly