### PR TITLE
Fix Serial communications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,4 +13,5 @@
 ### Fixed
 
 * #39 Firmware version
+* #41 Serial communications with the platform
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -165,14 +165,14 @@ namespace hf {
             void checkFailsafe(void)
             {
                 if (_state.armed &&
-                   (_receiver->lostSignal(_receiver->_bypassReceiver) || _board->isBatteryLow())) {
+                   (_receiver->lostSignal(_receiver->getBypassReceiver()) || _board->isBatteryLow())) {
                     _mixer->cutMotors();
                     _state.armed = false;
                     _failsafe = true;
                     _board->showArmedStatus(false);
-                    if (_receiver->_lostSignal)
+                    if (_receiver->getLostSignal())
                     {
-                      _receiver->_bypassReceiver = false;
+                      _receiver->setBypassReceiver(false);
                     }
                 }
             } 
@@ -219,7 +219,7 @@ namespace hf {
 
             void doSerialComms(void)
             {
-                //_receiver->gotFrame = false;
+                _receiver->setGotNewFrame(false);
                 _board->setSerialFlag();
                 while (_board->serialAvailableBytes() > 0) {
                     if (MspParser::parse(_board->serialReadByte())) {
@@ -349,14 +349,14 @@ namespace hf {
                 float _channels[6] = {c2, c3, c1, c4, c6, c5};
                 memset(_receiver->rawvals, 0, _receiver->MAXCHAN*sizeof(float));
                 memcpy(_receiver->rawvals, _channels, _receiver->MAXCHAN*sizeof(float));
-                _receiver->gotFrame = true;
-                _receiver->_bypassReceiver = true;
-                _receiver->_lostSignal = false;
+                _receiver->setGotNewFrame(true);
+                _receiver->setBypassReceiver(true);
+                _receiver->setLostSignal(false);
             }
             
             virtual void handle_LOST_SIGNAL_Request(uint8_t  flag) override
             {
-                _receiver->_lostSignal = flag;
+                _receiver->setLostSignal(flag);
             }
 
             virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t version) override

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -257,7 +257,9 @@ namespace hf {
         }
         
         // Setters and getters of the attributes required to be able to use the
-        // ESP32 and MSP messages as a receiver
+        // ESP32 and MSP messages as a receiver. For now, we offer this possibility
+        // to work with any receiver by implementing this methods in the receiver
+        // class 
         
         void setGotNewFrame(bool gotNewFrame)
         {

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -41,6 +41,9 @@ namespace hf {
         bool _bypassReceiver = false;
         // Allow to trigger lost signal from Hackflight via this flag 
         bool _lostSignal = false;
+        // Receiving via Wifi should set this boolean to true so that RC values
+        // are updated
+        bool _gotNewFrame = false;
 
         static constexpr uint8_t DEFAULT_CHANNEL_MAP[6] = {0, 1, 2, 3, 4, 5};
 
@@ -87,10 +90,6 @@ namespace hf {
 
         protected: 
 
-        // Receiving via Wifi should set this boolean to true so that RC values
-        // are updated
-        bool gotFrame = false;
-
         // maximum number of channels that any receiver will send (of which we'll use six)
         static const uint8_t MAXCHAN = 8;
 
@@ -112,6 +111,7 @@ namespace hf {
         // These must be overridden for each receiver
         virtual bool gotNewFrame(void) = 0;
         virtual void readRawvals(void) = 0;
+
         // Enable readRawvals bypass 
         void readRawvals(bool bypass)
         {
@@ -173,7 +173,7 @@ namespace hf {
         bool getDemands(float yawAngle)
         {
             // Wait till there's a new frame
-            if (!gotNewFrame() && !gotFrame) return false;
+            if (!gotNewFrame() && !_gotNewFrame) return false;
 
             // Read raw channel values
             readRawvals(_bypassReceiver);
@@ -255,7 +255,39 @@ namespace hf {
         {
             _trimYaw = trim;
         }
-
+        
+        // Setters and getters of the attributes required to be able to use the
+        // ESP32 and MSP messages as a receiver
+        
+        void setGotNewFrame(bool gotNewFrame)
+        {
+            _gotNewFrame = gotNewFrame;
+        }
+        
+        void setBypassReceiver(bool bypass)
+        {
+            _bypassReceiver = bypass;
+        }
+        
+        void setLostSignal(bool lost)
+        {
+            _lostSignal = lost;
+        }
+        
+        bool getGotNewFrame(void)
+        {
+            return _gotNewFrame;
+        }
+        
+        bool getBypassReceiver(void)
+        {
+            return _bypassReceiver;
+        }
+        
+        bool getLostSignal(void)
+        {
+            return _lostSignal;
+        }
 
     }; // class Receiver
 


### PR DESCRIPTION
## Issue this PR addresses

In order to enable receiving RC data via WiFi and SBUS at the same time Hackflight should be able to set/get the values of some flags in the `Receiver` class.  This was being done by directly accessing this members of the `Receiver` class. 

However, this was giving problems and resulting in serial communications not working as expected. Serial communications worked with Hackflight's GCS, didn't work with BonaDrone's platform when connecting via USB and worked with BonaDrone's platform when connecting via WiFi.

## Expected behaviour after merge 

Serial communications work as expected.