### PR TITLE
Enable setting rangefinder calibration parameters via MSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * #43 ESKF estimates vertical position and velocity
 * #43 Add IMU to the list of available sensors 
 * #43 Allow to define the frequency at which sensors correct/update ESKF estimates
+* #45 Allow to set rangefinder parameters with an MSP message
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -202,6 +202,13 @@
   "SET_POSITIONING_BOARD":
   [{"ID": 225},
    {"comment": "Specify whether the positioning board is present or not"},
-   {"hasBoard": "byte"}]
+   {"hasBoard": "byte"}],
+   
+  "SET_RANGE_PARAMETERS":
+  [{"ID": 221},
+   {"comment": "Range calibration parameters, which is the translation from IMU to range frames"},
+   {"rx": "float"},
+   {"ry": "float"},
+   {"rz": "float"}]
 
 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -274,6 +274,9 @@ namespace hf {
             // Map parameters to EEPROM addresses
             static const uint8_t GENERAL_CONFIG    = 0;
             static const uint8_t PID_CONSTANTS     = 1;
+            static const uint8_t N_PID_CONSTANTS   = 16;
+            static const uint8_t RANGE_PARAMS      = PID_CONSTANTS + N_PID_CONSTANTS * sizeof(float);
+            static const uint8_t N_RANGE_PARAMS    = 3;
             // booleans values are stored as the bits of the byte at address 0
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
@@ -401,7 +404,17 @@ namespace hf {
                 EEPROM.put(PID_CONSTANTS + 9 * sizeof(float), altHoldVelI);
                 EEPROM.put(PID_CONSTANTS + 10 * sizeof(float), altHoldVelD);
                 EEPROM.put(PID_CONSTANTS + 11 * sizeof(float), minAltitude);
-                
+                EEPROM.put(PID_CONSTANTS + 12 * sizeof(float), param6);
+                EEPROM.put(PID_CONSTANTS + 13 * sizeof(float), param7);
+                EEPROM.put(PID_CONSTANTS + 14 * sizeof(float), param8);
+                EEPROM.put(PID_CONSTANTS + 15 * sizeof(float), param9);
+            }
+            
+            virtual void handle_SET_RANGE_PARAMETERS_Request(float rx, float ry, float rz) override
+            {
+              EEPROM.put(RANGE_PARAMS, rx);
+              EEPROM.put(RANGE_PARAMS + 1 * sizeof(float), ry);
+              EEPROM.put(RANGE_PARAMS + 2 * sizeof(float), rz);
             }
 
         public:

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -72,6 +72,10 @@ namespace hf {
               float _altHoldVelI;
               float _altHoldVelD;
               float _minAltitude;
+              // range params
+              float _rx;
+              float _ry;
+              float _rz;
 
 
               // Required objects to run Hackflight 
@@ -95,12 +99,14 @@ namespace hf {
                   EEPROM.get(PID_CONSTANTS + 4 * sizeof(float), _gyroYawI);
                   EEPROM.get(PID_CONSTANTS + 5 * sizeof(float), _demandsToRate);
                   EEPROM.get(PID_CONSTANTS + 6 * sizeof(float), _levelP);
-                  EEPROM.put(PID_CONSTANTS + 7 * sizeof(float), _altHoldP);
-                  EEPROM.put(PID_CONSTANTS + 8 * sizeof(float), _altHoldVelP);
-                  EEPROM.put(PID_CONSTANTS + 9 * sizeof(float), _altHoldVelI);
-                  EEPROM.put(PID_CONSTANTS + 10 * sizeof(float), _altHoldVelD);
-                  EEPROM.put(PID_CONSTANTS + 11 * sizeof(float), _minAltitude);
-                  
+                  EEPROM.get(PID_CONSTANTS + 7 * sizeof(float), _altHoldP);
+                  EEPROM.get(PID_CONSTANTS + 8 * sizeof(float), _altHoldVelP);
+                  EEPROM.get(PID_CONSTANTS + 9 * sizeof(float), _altHoldVelI);
+                  EEPROM.get(PID_CONSTANTS + 10 * sizeof(float), _altHoldVelD);
+                  EEPROM.get(PID_CONSTANTS + 11 * sizeof(float), _minAltitude);
+                  EEPROM.get(RANGE_PARAMS, _rx);
+                  EEPROM.get(RANGE_PARAMS + 1 * sizeof(float), _ry);
+                  EEPROM.get(RANGE_PARAMS + 2 * sizeof(float), _rz);
               }
 
         protected:
@@ -157,6 +163,7 @@ namespace hf {
                 {
                     hf::VL53L1X_Rangefinder rangefinder;
                     rangefinder.begin();
+                    rangefinder.setCalibration(_rx, _ry, _rz);
                     h.addSensor(&rangefinder);
                     h.eskf.addSensorESKF(&rangefinder);
                     

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -303,28 +303,14 @@ namespace hf {
                 processMissionCommand(_command);
                 switch (_command) {
 
-                    case 102:
+                    case 5:
                     {
-                        int16_t accx = 0;
-                        int16_t accy = 0;
-                        int16_t accz = 0;
-                        int16_t gyrx = 0;
-                        int16_t gyry = 0;
-                        int16_t gyrz = 0;
-                        int16_t magx = 0;
-                        int16_t magy = 0;
-                        int16_t magz = 0;
-                        handle_RAW_IMU_Request(accx, accy, accz, gyrx, gyry, gyrz, magx, magy, magz);
-                        prepareToSendShorts(9);
-                        sendShort(accx);
-                        sendShort(accy);
-                        sendShort(accz);
-                        sendShort(gyrx);
-                        sendShort(gyry);
-                        sendShort(gyrz);
-                        sendShort(magx);
-                        sendShort(magy);
-                        sendShort(magz);
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_FORWARD_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
                         serialize8(_checksum);
                         } break;
 
@@ -347,206 +333,33 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
-                    case 222:
+                    case 11:
                     {
-                        float c1 = 0;
-                        memcpy(&c1,  &_inBuf[0], sizeof(float));
+                        uint8_t seconds = 0;
+                        uint8_t code = 0;
+                        handle_WP_HOVER_Request(seconds, code);
+                        prepareToSendBytes(2);
+                        sendByte(seconds);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
 
-                        float c2 = 0;
-                        memcpy(&c2,  &_inBuf[4], sizeof(float));
+                    case 223:
+                    {
+                        uint8_t version = 0;
+                        memcpy(&version,  &_inBuf[0], sizeof(uint8_t));
 
-                        float c3 = 0;
-                        memcpy(&c3,  &_inBuf[8], sizeof(float));
-
-                        float c4 = 0;
-                        memcpy(&c4,  &_inBuf[12], sizeof(float));
-
-                        float c5 = 0;
-                        memcpy(&c5,  &_inBuf[16], sizeof(float));
-
-                        float c6 = 0;
-                        memcpy(&c6,  &_inBuf[20], sizeof(float));
-
-                        handle_SET_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
+                        handle_SET_MOSQUITO_VERSION_Request(version);
                         acknowledgeResponse();
                         } break;
 
-                    case 226:
+                    case 23:
                     {
+                        incomingMission = incomingMission ? false : true;
                         uint8_t flag = 0;
-                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_LOST_SIGNAL_Request(flag);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 122:
-                    {
-                        float roll = 0;
-                        float pitch = 0;
-                        float yaw = 0;
-                        handle_ATTITUDE_RADIANS_Request(roll, pitch, yaw);
-                        prepareToSendFloats(3);
-                        sendFloat(roll);
-                        sendFloat(pitch);
-                        sendFloat(yaw);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 123:
-                    {
-                        float estalt = 0;
-                        float vario = 0;
-                        handle_ALTITUDE_METERS_Request(estalt, vario);
-                        prepareToSendFloats(2);
-                        sendFloat(estalt);
-                        sendFloat(vario);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 126:
-                    {
-                        float agl = 0;
-                        float flowx = 0;
-                        float flowy = 0;
-                        handle_LOITER_Request(agl, flowx, flowy);
-                        prepareToSendFloats(3);
-                        sendFloat(agl);
-                        sendFloat(flowx);
-                        sendFloat(flowy);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 216:
-                    {
-                        uint8_t flag = 0;
-                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_SET_ARMED_Request(flag);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 199:
-                    {
-                        int32_t value1 = 0;
-                        int32_t value2 = 0;
-                        handle_FAKE_INT_Request(value1, value2);
-                        prepareToSendInts(2);
-                        sendInt(value1);
-                        sendInt(value2);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 215:
-                    {
-                        float m1 = 0;
-                        memcpy(&m1,  &_inBuf[0], sizeof(float));
-
-                        float m2 = 0;
-                        memcpy(&m2,  &_inBuf[4], sizeof(float));
-
-                        float m3 = 0;
-                        memcpy(&m3,  &_inBuf[8], sizeof(float));
-
-                        float m4 = 0;
-                        memcpy(&m4,  &_inBuf[12], sizeof(float));
-
-                        handle_SET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 124:
-                    {
-                        float m1 = 0;
-                        float m2 = 0;
-                        float m3 = 0;
-                        float m4 = 0;
-                        handle_GET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
-                        prepareToSendFloats(4);
-                        sendFloat(m1);
-                        sendFloat(m2);
-                        sendFloat(m3);
-                        sendFloat(m4);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 0:
-                    {
-                        uint8_t code = 0;
-                        handle_CLEAR_EEPROM_Request(code);
+                        handle_WP_MISSION_FLAG_Request(flag);
                         prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 1:
-                    {
-                        uint8_t code = 0;
-                        handle_WP_ARM_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 2:
-                    {
-                        uint8_t code = 0;
-                        handle_WP_DISARM_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 3:
-                    {
-                        uint8_t code = 0;
-                        handle_WP_LAND_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 4:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_TAKE_OFF_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 5:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_FORWARD_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 6:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_BACKWARD_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 7:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_LEFT_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
+                        sendByte(flag);
                         serialize8(_checksum);
                         } break;
 
@@ -561,95 +374,18 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
-                    case 9:
+                    case 221:
                     {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_CHANGE_ALTITUDE_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
+                        float rx = 0;
+                        memcpy(&rx,  &_inBuf[0], sizeof(float));
 
-                    case 10:
-                    {
-                        uint8_t speed = 0;
-                        uint8_t code = 0;
-                        handle_WP_CHANGE_SPEED_Request(speed, code);
-                        prepareToSendBytes(2);
-                        sendByte(speed);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
+                        float ry = 0;
+                        memcpy(&ry,  &_inBuf[4], sizeof(float));
 
-                    case 11:
-                    {
-                        uint8_t seconds = 0;
-                        uint8_t code = 0;
-                        handle_WP_HOVER_Request(seconds, code);
-                        prepareToSendBytes(2);
-                        sendByte(seconds);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
+                        float rz = 0;
+                        memcpy(&rz,  &_inBuf[8], sizeof(float));
 
-                    case 12:
-                    {
-                        uint8_t degrees = 0;
-                        uint8_t code = 0;
-                        handle_WP_TURN_CW_Request(degrees, code);
-                        prepareToSendBytes(2);
-                        sendByte(degrees);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 13:
-                    {
-                        uint8_t degrees = 0;
-                        uint8_t code = 0;
-                        handle_WP_TURN_CCW_Request(degrees, code);
-                        prepareToSendBytes(2);
-                        sendByte(degrees);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 23:
-                    {
-                        incomingMission = incomingMission ? false : true;
-                        uint8_t flag = 0;
-                        handle_WP_MISSION_FLAG_Request(flag);
-                        prepareToSendBytes(1);
-                        sendByte(flag);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 30:
-                    {
-                        uint8_t flag = 0;
-                        handle_WP_MISSION_BEGIN_Request(flag);
-                        prepareToSendBytes(1);
-                        sendByte(flag);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 50:
-                    {
-                        uint8_t version = 0;
-                        handle_FIRMWARE_VERSION_Request(version);
-                        prepareToSendBytes(1);
-                        sendByte(version);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 223:
-                    {
-                        uint8_t version = 0;
-                        memcpy(&version,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_SET_MOSQUITO_VERSION_Request(version);
+                        handle_SET_RANGE_PARAMETERS_Request(rx, ry, rz);
                         acknowledgeResponse();
                         } break;
 
@@ -707,6 +443,162 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 0:
+                    {
+                        uint8_t code = 0;
+                        handle_CLEAR_EEPROM_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 13:
+                    {
+                        uint8_t degrees = 0;
+                        uint8_t code = 0;
+                        handle_WP_TURN_CCW_Request(degrees, code);
+                        prepareToSendBytes(2);
+                        sendByte(degrees);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 102:
+                    {
+                        int16_t accx = 0;
+                        int16_t accy = 0;
+                        int16_t accz = 0;
+                        int16_t gyrx = 0;
+                        int16_t gyry = 0;
+                        int16_t gyrz = 0;
+                        int16_t magx = 0;
+                        int16_t magy = 0;
+                        int16_t magz = 0;
+                        handle_RAW_IMU_Request(accx, accy, accz, gyrx, gyry, gyrz, magx, magy, magz);
+                        prepareToSendShorts(9);
+                        sendShort(accx);
+                        sendShort(accy);
+                        sendShort(accz);
+                        sendShort(gyrx);
+                        sendShort(gyry);
+                        sendShort(gyrz);
+                        sendShort(magx);
+                        sendShort(magy);
+                        sendShort(magz);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 216:
+                    {
+                        uint8_t flag = 0;
+                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_ARMED_Request(flag);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 215:
+                    {
+                        float m1 = 0;
+                        memcpy(&m1,  &_inBuf[0], sizeof(float));
+
+                        float m2 = 0;
+                        memcpy(&m2,  &_inBuf[4], sizeof(float));
+
+                        float m3 = 0;
+                        memcpy(&m3,  &_inBuf[8], sizeof(float));
+
+                        float m4 = 0;
+                        memcpy(&m4,  &_inBuf[12], sizeof(float));
+
+                        handle_SET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 226:
+                    {
+                        uint8_t flag = 0;
+                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_LOST_SIGNAL_Request(flag);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 7:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_LEFT_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 4:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_TAKE_OFF_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 12:
+                    {
+                        uint8_t degrees = 0;
+                        uint8_t code = 0;
+                        handle_WP_TURN_CW_Request(degrees, code);
+                        prepareToSendBytes(2);
+                        sendByte(degrees);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 50:
+                    {
+                        uint8_t version = 0;
+                        handle_FIRMWARE_VERSION_Request(version);
+                        prepareToSendBytes(1);
+                        sendByte(version);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 122:
+                    {
+                        float roll = 0;
+                        float pitch = 0;
+                        float yaw = 0;
+                        handle_ATTITUDE_RADIANS_Request(roll, pitch, yaw);
+                        prepareToSendFloats(3);
+                        sendFloat(roll);
+                        sendFloat(pitch);
+                        sendFloat(yaw);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 10:
+                    {
+                        uint8_t speed = 0;
+                        uint8_t code = 0;
+                        handle_WP_CHANGE_SPEED_Request(speed, code);
+                        prepareToSendBytes(2);
+                        sendByte(speed);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 3:
+                    {
+                        uint8_t code = 0;
+                        handle_WP_LAND_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
                     case 225:
                     {
                         uint8_t hasBoard = 0;
@@ -716,12 +608,186 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 2:
+                    {
+                        uint8_t code = 0;
+                        handle_WP_DISARM_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 1:
+                    {
+                        uint8_t code = 0;
+                        handle_WP_ARM_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 6:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_BACKWARD_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 199:
+                    {
+                        int32_t value1 = 0;
+                        int32_t value2 = 0;
+                        handle_FAKE_INT_Request(value1, value2);
+                        prepareToSendInts(2);
+                        sendInt(value1);
+                        sendInt(value2);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 123:
+                    {
+                        float estalt = 0;
+                        float vario = 0;
+                        handle_ALTITUDE_METERS_Request(estalt, vario);
+                        prepareToSendFloats(2);
+                        sendFloat(estalt);
+                        sendFloat(vario);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 124:
+                    {
+                        float m1 = 0;
+                        float m2 = 0;
+                        float m3 = 0;
+                        float m4 = 0;
+                        handle_GET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
+                        prepareToSendFloats(4);
+                        sendFloat(m1);
+                        sendFloat(m2);
+                        sendFloat(m3);
+                        sendFloat(m4);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 222:
+                    {
+                        float c1 = 0;
+                        memcpy(&c1,  &_inBuf[0], sizeof(float));
+
+                        float c2 = 0;
+                        memcpy(&c2,  &_inBuf[4], sizeof(float));
+
+                        float c3 = 0;
+                        memcpy(&c3,  &_inBuf[8], sizeof(float));
+
+                        float c4 = 0;
+                        memcpy(&c4,  &_inBuf[12], sizeof(float));
+
+                        float c5 = 0;
+                        memcpy(&c5,  &_inBuf[16], sizeof(float));
+
+                        float c6 = 0;
+                        memcpy(&c6,  &_inBuf[20], sizeof(float));
+
+                        handle_SET_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 126:
+                    {
+                        float agl = 0;
+                        float flowx = 0;
+                        float flowy = 0;
+                        handle_LOITER_Request(agl, flowx, flowy);
+                        prepareToSendFloats(3);
+                        sendFloat(agl);
+                        sendFloat(flowx);
+                        sendFloat(flowy);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 9:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_CHANGE_ALTITUDE_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 30:
+                    {
+                        uint8_t flag = 0;
+                        handle_WP_MISSION_BEGIN_Request(flag);
+                        prepareToSendBytes(1);
+                        sendByte(flag);
+                        serialize8(_checksum);
+                        } break;
+
                 }
             }
 
             void dispatchDataMessage(void)
             {
                 switch (_command) {
+
+                    case 5:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_FORWARD_Data(meters, code);
+                        } break;
+
+                    case 121:
+                    {
+                        float c1 = getArgument(0);
+                        float c2 = getArgument(1);
+                        float c3 = getArgument(2);
+                        float c4 = getArgument(3);
+                        float c5 = getArgument(4);
+                        float c6 = getArgument(5);
+                        handle_RC_NORMAL_Data(c1, c2, c3, c4, c5, c6);
+                        } break;
+
+                    case 11:
+                    {
+                        uint8_t seconds = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_HOVER_Data(seconds, code);
+                        } break;
+
+                    case 23:
+                    {
+                        uint8_t flag = getArgument(0);
+                        handle_WP_MISSION_FLAG_Data(flag);
+                        } break;
+
+                    case 8:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_RIGHT_Data(meters, code);
+                        } break;
+
+                    case 0:
+                    {
+                        uint8_t code = getArgument(0);
+                        handle_CLEAR_EEPROM_Data(code);
+                        } break;
+
+                    case 13:
+                    {
+                        uint8_t degrees = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_TURN_CCW_Data(degrees, code);
+                        } break;
 
                     case 102:
                     {
@@ -737,15 +803,31 @@ namespace hf {
                         handle_RAW_IMU_Data(accx, accy, accz, gyrx, gyry, gyrz, magx, magy, magz);
                         } break;
 
-                    case 121:
+                    case 7:
                     {
-                        float c1 = getArgument(0);
-                        float c2 = getArgument(1);
-                        float c3 = getArgument(2);
-                        float c4 = getArgument(3);
-                        float c5 = getArgument(4);
-                        float c6 = getArgument(5);
-                        handle_RC_NORMAL_Data(c1, c2, c3, c4, c5, c6);
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_LEFT_Data(meters, code);
+                        } break;
+
+                    case 4:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_TAKE_OFF_Data(meters, code);
+                        } break;
+
+                    case 12:
+                    {
+                        uint8_t degrees = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_TURN_CW_Data(degrees, code);
+                        } break;
+
+                    case 50:
+                    {
+                        uint8_t version = getArgument(0);
+                        handle_FIRMWARE_VERSION_Data(version);
                         } break;
 
                     case 122:
@@ -756,19 +838,36 @@ namespace hf {
                         handle_ATTITUDE_RADIANS_Data(roll, pitch, yaw);
                         } break;
 
-                    case 123:
+                    case 10:
                     {
-                        float estalt = getArgument(0);
-                        float vario = getArgument(1);
-                        handle_ALTITUDE_METERS_Data(estalt, vario);
+                        uint8_t speed = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_CHANGE_SPEED_Data(speed, code);
                         } break;
 
-                    case 126:
+                    case 3:
                     {
-                        float agl = getArgument(0);
-                        float flowx = getArgument(1);
-                        float flowy = getArgument(2);
-                        handle_LOITER_Data(agl, flowx, flowy);
+                        uint8_t code = getArgument(0);
+                        handle_WP_LAND_Data(code);
+                        } break;
+
+                    case 2:
+                    {
+                        uint8_t code = getArgument(0);
+                        handle_WP_DISARM_Data(code);
+                        } break;
+
+                    case 1:
+                    {
+                        uint8_t code = getArgument(0);
+                        handle_WP_ARM_Data(code);
+                        } break;
+
+                    case 6:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_BACKWARD_Data(meters, code);
                         } break;
 
                     case 199:
@@ -776,6 +875,13 @@ namespace hf {
                         int32_t value1 = getArgument(0);
                         int32_t value2 = getArgument(1);
                         handle_FAKE_INT_Data(value1, value2);
+                        } break;
+
+                    case 123:
+                    {
+                        float estalt = getArgument(0);
+                        float vario = getArgument(1);
+                        handle_ALTITUDE_METERS_Data(estalt, vario);
                         } break;
 
                     case 124:
@@ -787,63 +893,12 @@ namespace hf {
                         handle_GET_MOTOR_NORMAL_Data(m1, m2, m3, m4);
                         } break;
 
-                    case 0:
+                    case 126:
                     {
-                        uint8_t code = getArgument(0);
-                        handle_CLEAR_EEPROM_Data(code);
-                        } break;
-
-                    case 1:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_WP_ARM_Data(code);
-                        } break;
-
-                    case 2:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_WP_DISARM_Data(code);
-                        } break;
-
-                    case 3:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_WP_LAND_Data(code);
-                        } break;
-
-                    case 4:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_TAKE_OFF_Data(meters, code);
-                        } break;
-
-                    case 5:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_FORWARD_Data(meters, code);
-                        } break;
-
-                    case 6:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_BACKWARD_Data(meters, code);
-                        } break;
-
-                    case 7:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_LEFT_Data(meters, code);
-                        } break;
-
-                    case 8:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_RIGHT_Data(meters, code);
+                        float agl = getArgument(0);
+                        float flowx = getArgument(1);
+                        float flowy = getArgument(2);
+                        handle_LOITER_Data(agl, flowx, flowy);
                         } break;
 
                     case 9:
@@ -853,50 +908,10 @@ namespace hf {
                         handle_WP_CHANGE_ALTITUDE_Data(meters, code);
                         } break;
 
-                    case 10:
-                    {
-                        uint8_t speed = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_CHANGE_SPEED_Data(speed, code);
-                        } break;
-
-                    case 11:
-                    {
-                        uint8_t seconds = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_HOVER_Data(seconds, code);
-                        } break;
-
-                    case 12:
-                    {
-                        uint8_t degrees = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_TURN_CW_Data(degrees, code);
-                        } break;
-
-                    case 13:
-                    {
-                        uint8_t degrees = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_TURN_CCW_Data(degrees, code);
-                        } break;
-
-                    case 23:
-                    {
-                        uint8_t flag = getArgument(0);
-                        handle_WP_MISSION_FLAG_Data(flag);
-                        } break;
-
                     case 30:
                     {
                         uint8_t flag = getArgument(0);
                         handle_WP_MISSION_BEGIN_Data(flag);
-                        } break;
-
-                    case 50:
-                    {
-                        uint8_t version = getArgument(0);
-                        handle_FIRMWARE_VERSION_Data(version);
                         } break;
 
                 }
@@ -904,30 +919,16 @@ namespace hf {
 
         protected:
 
-            virtual void handle_RAW_IMU_Request(int16_t & accx, int16_t & accy, int16_t & accz, int16_t & gyrx, int16_t & gyry, int16_t & gyrz, int16_t & magx, int16_t & magy, int16_t & magz)
+            virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code)
             {
-                (void)accx;
-                (void)accy;
-                (void)accz;
-                (void)gyrx;
-                (void)gyry;
-                (void)gyrz;
-                (void)magx;
-                (void)magy;
-                (void)magz;
+                (void)meters;
+                (void)code;
             }
 
-            virtual void handle_RAW_IMU_Data(int16_t & accx, int16_t & accy, int16_t & accz, int16_t & gyrx, int16_t & gyry, int16_t & gyrz, int16_t & magx, int16_t & magy, int16_t & magz)
+            virtual void handle_WP_GO_FORWARD_Data(uint8_t & meters, uint8_t & code)
             {
-                (void)accx;
-                (void)accy;
-                (void)accz;
-                (void)gyrx;
-                (void)gyry;
-                (void)gyrz;
-                (void)magx;
-                (void)magy;
-                (void)magz;
+                (void)meters;
+                (void)code;
             }
 
             virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6)
@@ -950,216 +951,36 @@ namespace hf {
                 (void)c6;
             }
 
-            virtual void handle_SET_RC_NORMAL_Request(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code)
             {
-                (void)c1;
-                (void)c2;
-                (void)c3;
-                (void)c4;
-                (void)c5;
-                (void)c6;
+                (void)seconds;
+                (void)code;
             }
 
-            virtual void handle_SET_RC_NORMAL_Data(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            virtual void handle_WP_HOVER_Data(uint8_t & seconds, uint8_t & code)
             {
-                (void)c1;
-                (void)c2;
-                (void)c3;
-                (void)c4;
-                (void)c5;
-                (void)c6;
+                (void)seconds;
+                (void)code;
             }
 
-            virtual void handle_LOST_SIGNAL_Request(uint8_t  flag)
+            virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t  version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_SET_MOSQUITO_VERSION_Data(uint8_t  version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_WP_MISSION_FLAG_Request(uint8_t & flag)
             {
                 (void)flag;
             }
 
-            virtual void handle_LOST_SIGNAL_Data(uint8_t  flag)
+            virtual void handle_WP_MISSION_FLAG_Data(uint8_t & flag)
             {
                 (void)flag;
-            }
-
-            virtual void handle_ATTITUDE_RADIANS_Request(float & roll, float & pitch, float & yaw)
-            {
-                (void)roll;
-                (void)pitch;
-                (void)yaw;
-            }
-
-            virtual void handle_ATTITUDE_RADIANS_Data(float & roll, float & pitch, float & yaw)
-            {
-                (void)roll;
-                (void)pitch;
-                (void)yaw;
-            }
-
-            virtual void handle_ALTITUDE_METERS_Request(float & estalt, float & vario)
-            {
-                (void)estalt;
-                (void)vario;
-            }
-
-            virtual void handle_ALTITUDE_METERS_Data(float & estalt, float & vario)
-            {
-                (void)estalt;
-                (void)vario;
-            }
-
-            virtual void handle_LOITER_Request(float & agl, float & flowx, float & flowy)
-            {
-                (void)agl;
-                (void)flowx;
-                (void)flowy;
-            }
-
-            virtual void handle_LOITER_Data(float & agl, float & flowx, float & flowy)
-            {
-                (void)agl;
-                (void)flowx;
-                (void)flowy;
-            }
-
-            virtual void handle_SET_ARMED_Request(uint8_t  flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_SET_ARMED_Data(uint8_t  flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_FAKE_INT_Request(int32_t & value1, int32_t & value2)
-            {
-                (void)value1;
-                (void)value2;
-            }
-
-            virtual void handle_FAKE_INT_Data(int32_t & value1, int32_t & value2)
-            {
-                (void)value1;
-                (void)value2;
-            }
-
-            virtual void handle_SET_MOTOR_NORMAL_Request(float  m1, float  m2, float  m3, float  m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_SET_MOTOR_NORMAL_Data(float  m1, float  m2, float  m3, float  m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_GET_MOTOR_NORMAL_Data(float & m1, float & m2, float & m3, float & m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_CLEAR_EEPROM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_CLEAR_EEPROM_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_ARM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_ARM_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_DISARM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_DISARM_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_LAND_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_LAND_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_TAKE_OFF_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_FORWARD_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_BACKWARD_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_LEFT_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
             }
 
             virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code)
@@ -1174,104 +995,18 @@ namespace hf {
                 (void)code;
             }
 
-            virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code)
+            virtual void handle_SET_RANGE_PARAMETERS_Request(float  rx, float  ry, float  rz)
             {
-                (void)meters;
-                (void)code;
+                (void)rx;
+                (void)ry;
+                (void)rz;
             }
 
-            virtual void handle_WP_CHANGE_ALTITUDE_Data(uint8_t & meters, uint8_t & code)
+            virtual void handle_SET_RANGE_PARAMETERS_Data(float  rx, float  ry, float  rz)
             {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code)
-            {
-                (void)speed;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_SPEED_Data(uint8_t & speed, uint8_t & code)
-            {
-                (void)speed;
-                (void)code;
-            }
-
-            virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code)
-            {
-                (void)seconds;
-                (void)code;
-            }
-
-            virtual void handle_WP_HOVER_Data(uint8_t & seconds, uint8_t & code)
-            {
-                (void)seconds;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CW_Data(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CCW_Data(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_MISSION_FLAG_Request(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_WP_MISSION_FLAG_Data(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_WP_MISSION_BEGIN_Data(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_FIRMWARE_VERSION_Request(uint8_t & version)
-            {
-                (void)version;
-            }
-
-            virtual void handle_FIRMWARE_VERSION_Data(uint8_t & version)
-            {
-                (void)version;
-            }
-
-            virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t  version)
-            {
-                (void)version;
-            }
-
-            virtual void handle_SET_MOSQUITO_VERSION_Data(uint8_t  version)
-            {
-                (void)version;
+                (void)rx;
+                (void)ry;
+                (void)rz;
             }
 
             virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
@@ -1314,6 +1049,172 @@ namespace hf {
                 (void)param9;
             }
 
+            virtual void handle_CLEAR_EEPROM_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_CLEAR_EEPROM_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CCW_Data(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_RAW_IMU_Request(int16_t & accx, int16_t & accy, int16_t & accz, int16_t & gyrx, int16_t & gyry, int16_t & gyrz, int16_t & magx, int16_t & magy, int16_t & magz)
+            {
+                (void)accx;
+                (void)accy;
+                (void)accz;
+                (void)gyrx;
+                (void)gyry;
+                (void)gyrz;
+                (void)magx;
+                (void)magy;
+                (void)magz;
+            }
+
+            virtual void handle_RAW_IMU_Data(int16_t & accx, int16_t & accy, int16_t & accz, int16_t & gyrx, int16_t & gyry, int16_t & gyrz, int16_t & magx, int16_t & magy, int16_t & magz)
+            {
+                (void)accx;
+                (void)accy;
+                (void)accz;
+                (void)gyrx;
+                (void)gyry;
+                (void)gyrz;
+                (void)magx;
+                (void)magy;
+                (void)magz;
+            }
+
+            virtual void handle_SET_ARMED_Request(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_SET_ARMED_Data(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_SET_MOTOR_NORMAL_Request(float  m1, float  m2, float  m3, float  m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_SET_MOTOR_NORMAL_Data(float  m1, float  m2, float  m3, float  m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_LOST_SIGNAL_Request(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_LOST_SIGNAL_Data(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_LEFT_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_TAKE_OFF_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CW_Data(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_FIRMWARE_VERSION_Request(uint8_t & version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_FIRMWARE_VERSION_Data(uint8_t & version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_ATTITUDE_RADIANS_Request(float & roll, float & pitch, float & yaw)
+            {
+                (void)roll;
+                (void)pitch;
+                (void)yaw;
+            }
+
+            virtual void handle_ATTITUDE_RADIANS_Data(float & roll, float & pitch, float & yaw)
+            {
+                (void)roll;
+                (void)pitch;
+                (void)yaw;
+            }
+
+            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code)
+            {
+                (void)speed;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_SPEED_Data(uint8_t & speed, uint8_t & code)
+            {
+                (void)speed;
+                (void)code;
+            }
+
+            virtual void handle_WP_LAND_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_LAND_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
             {
                 (void)hasBoard;
@@ -1324,7 +1225,395 @@ namespace hf {
                 (void)hasBoard;
             }
 
+            virtual void handle_WP_DISARM_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_DISARM_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_ARM_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_ARM_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_BACKWARD_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_FAKE_INT_Request(int32_t & value1, int32_t & value2)
+            {
+                (void)value1;
+                (void)value2;
+            }
+
+            virtual void handle_FAKE_INT_Data(int32_t & value1, int32_t & value2)
+            {
+                (void)value1;
+                (void)value2;
+            }
+
+            virtual void handle_ALTITUDE_METERS_Request(float & estalt, float & vario)
+            {
+                (void)estalt;
+                (void)vario;
+            }
+
+            virtual void handle_ALTITUDE_METERS_Data(float & estalt, float & vario)
+            {
+                (void)estalt;
+                (void)vario;
+            }
+
+            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_GET_MOTOR_NORMAL_Data(float & m1, float & m2, float & m3, float & m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_SET_RC_NORMAL_Request(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                (void)c1;
+                (void)c2;
+                (void)c3;
+                (void)c4;
+                (void)c5;
+                (void)c6;
+            }
+
+            virtual void handle_SET_RC_NORMAL_Data(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                (void)c1;
+                (void)c2;
+                (void)c3;
+                (void)c4;
+                (void)c5;
+                (void)c6;
+            }
+
+            virtual void handle_LOITER_Request(float & agl, float & flowx, float & flowy)
+            {
+                (void)agl;
+                (void)flowx;
+                (void)flowy;
+            }
+
+            virtual void handle_LOITER_Data(float & agl, float & flowx, float & flowy)
+            {
+                (void)agl;
+                (void)flowx;
+                (void)flowy;
+            }
+
+            virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_ALTITUDE_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_WP_MISSION_BEGIN_Data(uint8_t & flag)
+            {
+                (void)flag;
+            }
+
         public:
+
+            static uint8_t serialize_WP_GO_FORWARD_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 5;
+                bytes[5] = 5;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_GO_FORWARD(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 5;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_RC_NORMAL_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 121;
+                bytes[5] = 121;
+
+                return 6;
+            }
+
+            static uint8_t serialize_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 24;
+                bytes[4] = 121;
+
+                memcpy(&bytes[5], &c1, sizeof(float));
+                memcpy(&bytes[9], &c2, sizeof(float));
+                memcpy(&bytes[13], &c3, sizeof(float));
+                memcpy(&bytes[17], &c4, sizeof(float));
+                memcpy(&bytes[21], &c5, sizeof(float));
+                memcpy(&bytes[25], &c6, sizeof(float));
+
+                bytes[29] = CRC8(&bytes[3], 26);
+
+                return 30;
+            }
+
+            static uint8_t serialize_WP_HOVER_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 11;
+                bytes[5] = 11;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_HOVER(uint8_t bytes[], uint8_t  seconds, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 11;
+
+                memcpy(&bytes[5], &seconds, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_SET_MOSQUITO_VERSION(uint8_t bytes[], uint8_t  version)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 223;
+
+                memcpy(&bytes[5], &version, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_MISSION_FLAG_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 23;
+                bytes[5] = 23;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_MISSION_FLAG(uint8_t bytes[], uint8_t  flag)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 23;
+
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_GO_RIGHT_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 8;
+                bytes[5] = 8;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_GO_RIGHT(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 8;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_SET_RANGE_PARAMETERS(uint8_t bytes[], float  rx, float  ry, float  rz)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 12;
+                bytes[4] = 221;
+
+                memcpy(&bytes[5], &rx, sizeof(float));
+                memcpy(&bytes[9], &ry, sizeof(float));
+                memcpy(&bytes[13], &rz, sizeof(float));
+
+                bytes[17] = CRC8(&bytes[3], 14);
+
+                return 18;
+            }
+
+            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 64;
+                bytes[4] = 224;
+
+                memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
+                memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));
+                memcpy(&bytes[13], &gyroRollPitchD, sizeof(float));
+                memcpy(&bytes[17], &gyroYawP, sizeof(float));
+                memcpy(&bytes[21], &gyroYawI, sizeof(float));
+                memcpy(&bytes[25], &demandsToRate, sizeof(float));
+                memcpy(&bytes[29], &levelP, sizeof(float));
+                memcpy(&bytes[33], &altHoldP, sizeof(float));
+                memcpy(&bytes[37], &altHoldVelP, sizeof(float));
+                memcpy(&bytes[41], &altHoldVelI, sizeof(float));
+                memcpy(&bytes[45], &altHoldVelD, sizeof(float));
+                memcpy(&bytes[49], &minAltitude, sizeof(float));
+                memcpy(&bytes[53], &param6, sizeof(float));
+                memcpy(&bytes[57], &param7, sizeof(float));
+                memcpy(&bytes[61], &param8, sizeof(float));
+                memcpy(&bytes[65], &param9, sizeof(float));
+
+                bytes[69] = CRC8(&bytes[3], 66);
+
+                return 70;
+            }
+
+            static uint8_t serialize_CLEAR_EEPROM_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 0;
+                bytes[5] = 0;
+
+                return 6;
+            }
+
+            static uint8_t serialize_CLEAR_EEPROM(uint8_t bytes[], uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 0;
+
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_TURN_CCW_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 13;
+                bytes[5] = 13;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_TURN_CCW(uint8_t bytes[], uint8_t  degrees, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 13;
+
+                memcpy(&bytes[5], &degrees, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
 
             static uint8_t serialize_RAW_IMU_Request(uint8_t bytes[])
             {
@@ -1361,159 +1650,6 @@ namespace hf {
                 return 24;
             }
 
-            static uint8_t serialize_RC_NORMAL_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 121;
-                bytes[5] = 121;
-
-                return 6;
-            }
-
-            static uint8_t serialize_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 24;
-                bytes[4] = 121;
-
-                memcpy(&bytes[5], &c1, sizeof(float));
-                memcpy(&bytes[9], &c2, sizeof(float));
-                memcpy(&bytes[13], &c3, sizeof(float));
-                memcpy(&bytes[17], &c4, sizeof(float));
-                memcpy(&bytes[21], &c5, sizeof(float));
-                memcpy(&bytes[25], &c6, sizeof(float));
-
-                bytes[29] = CRC8(&bytes[3], 26);
-
-                return 30;
-            }
-
-            static uint8_t serialize_SET_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 24;
-                bytes[4] = 222;
-
-                memcpy(&bytes[5], &c1, sizeof(float));
-                memcpy(&bytes[9], &c2, sizeof(float));
-                memcpy(&bytes[13], &c3, sizeof(float));
-                memcpy(&bytes[17], &c4, sizeof(float));
-                memcpy(&bytes[21], &c5, sizeof(float));
-                memcpy(&bytes[25], &c6, sizeof(float));
-
-                bytes[29] = CRC8(&bytes[3], 26);
-
-                return 30;
-            }
-
-            static uint8_t serialize_LOST_SIGNAL(uint8_t bytes[], uint8_t  flag)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 226;
-
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_ATTITUDE_RADIANS_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 122;
-                bytes[5] = 122;
-
-                return 6;
-            }
-
-            static uint8_t serialize_ATTITUDE_RADIANS(uint8_t bytes[], float  roll, float  pitch, float  yaw)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 12;
-                bytes[4] = 122;
-
-                memcpy(&bytes[5], &roll, sizeof(float));
-                memcpy(&bytes[9], &pitch, sizeof(float));
-                memcpy(&bytes[13], &yaw, sizeof(float));
-
-                bytes[17] = CRC8(&bytes[3], 14);
-
-                return 18;
-            }
-
-            static uint8_t serialize_ALTITUDE_METERS_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 123;
-                bytes[5] = 123;
-
-                return 6;
-            }
-
-            static uint8_t serialize_ALTITUDE_METERS(uint8_t bytes[], float  estalt, float  vario)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 8;
-                bytes[4] = 123;
-
-                memcpy(&bytes[5], &estalt, sizeof(float));
-                memcpy(&bytes[9], &vario, sizeof(float));
-
-                bytes[13] = CRC8(&bytes[3], 10);
-
-                return 14;
-            }
-
-            static uint8_t serialize_LOITER_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 126;
-                bytes[5] = 126;
-
-                return 6;
-            }
-
-            static uint8_t serialize_LOITER(uint8_t bytes[], float  agl, float  flowx, float  flowy)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 12;
-                bytes[4] = 126;
-
-                memcpy(&bytes[5], &agl, sizeof(float));
-                memcpy(&bytes[9], &flowx, sizeof(float));
-                memcpy(&bytes[13], &flowy, sizeof(float));
-
-                bytes[17] = CRC8(&bytes[3], 14);
-
-                return 18;
-            }
-
             static uint8_t serialize_SET_ARMED(uint8_t bytes[], uint8_t  flag)
             {
                 bytes[0] = 36;
@@ -1527,34 +1663,6 @@ namespace hf {
                 bytes[6] = CRC8(&bytes[3], 3);
 
                 return 7;
-            }
-
-            static uint8_t serialize_FAKE_INT_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 199;
-                bytes[5] = 199;
-
-                return 6;
-            }
-
-            static uint8_t serialize_FAKE_INT(uint8_t bytes[], int32_t  value1, int32_t  value2)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 8;
-                bytes[4] = 199;
-
-                memcpy(&bytes[5], &value1, sizeof(int32_t));
-                memcpy(&bytes[9], &value2, sizeof(int32_t));
-
-                bytes[13] = CRC8(&bytes[3], 10);
-
-                return 14;
             }
 
             static uint8_t serialize_SET_MOTOR_NORMAL(uint8_t bytes[], float  m1, float  m2, float  m3, float  m4)
@@ -1575,226 +1683,19 @@ namespace hf {
                 return 22;
             }
 
-            static uint8_t serialize_GET_MOTOR_NORMAL_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 124;
-                bytes[5] = 124;
-
-                return 6;
-            }
-
-            static uint8_t serialize_GET_MOTOR_NORMAL(uint8_t bytes[], float  m1, float  m2, float  m3, float  m4)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 16;
-                bytes[4] = 124;
-
-                memcpy(&bytes[5], &m1, sizeof(float));
-                memcpy(&bytes[9], &m2, sizeof(float));
-                memcpy(&bytes[13], &m3, sizeof(float));
-                memcpy(&bytes[17], &m4, sizeof(float));
-
-                bytes[21] = CRC8(&bytes[3], 18);
-
-                return 22;
-            }
-
-            static uint8_t serialize_CLEAR_EEPROM_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 0;
-                bytes[5] = 0;
-
-                return 6;
-            }
-
-            static uint8_t serialize_CLEAR_EEPROM(uint8_t bytes[], uint8_t  code)
+            static uint8_t serialize_LOST_SIGNAL(uint8_t bytes[], uint8_t  flag)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 1;
-                bytes[4] = 0;
+                bytes[4] = 226;
 
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_ARM_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 1;
-                bytes[5] = 1;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_ARM(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 1;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 
                 return 7;
-            }
-
-            static uint8_t serialize_WP_DISARM_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 2;
-                bytes[5] = 2;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_DISARM(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 2;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_LAND_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 3;
-                bytes[5] = 3;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_LAND(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 3;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_TAKE_OFF_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 4;
-                bytes[5] = 4;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_TAKE_OFF(uint8_t bytes[], uint8_t  meters, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 4;
-
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_GO_FORWARD_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 5;
-                bytes[5] = 5;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_GO_FORWARD(uint8_t bytes[], uint8_t  meters, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 5;
-
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_GO_BACKWARD_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 6;
-                bytes[5] = 6;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_GO_BACKWARD(uint8_t bytes[], uint8_t  meters, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 6;
-
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
             }
 
             static uint8_t serialize_WP_GO_LEFT_Request(uint8_t bytes[])
@@ -1825,111 +1726,27 @@ namespace hf {
                 return 8;
             }
 
-            static uint8_t serialize_WP_GO_RIGHT_Request(uint8_t bytes[])
+            static uint8_t serialize_WP_TAKE_OFF_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 8;
-                bytes[5] = 8;
+                bytes[4] = 4;
+                bytes[5] = 4;
 
                 return 6;
             }
 
-            static uint8_t serialize_WP_GO_RIGHT(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            static uint8_t serialize_WP_TAKE_OFF(uint8_t bytes[], uint8_t  meters, uint8_t  code)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 2;
-                bytes[4] = 8;
+                bytes[4] = 4;
 
                 memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_CHANGE_ALTITUDE_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 9;
-                bytes[5] = 9;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_CHANGE_ALTITUDE(uint8_t bytes[], uint8_t  meters, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 9;
-
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_CHANGE_SPEED_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 10;
-                bytes[5] = 10;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_CHANGE_SPEED(uint8_t bytes[], uint8_t  speed, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 10;
-
-                memcpy(&bytes[5], &speed, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_HOVER_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 11;
-                bytes[5] = 11;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_HOVER(uint8_t bytes[], uint8_t  seconds, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 11;
-
-                memcpy(&bytes[5], &seconds, sizeof(uint8_t));
                 memcpy(&bytes[6], &code, sizeof(uint8_t));
 
                 bytes[7] = CRC8(&bytes[3], 4);
@@ -1965,88 +1782,6 @@ namespace hf {
                 return 8;
             }
 
-            static uint8_t serialize_WP_TURN_CCW_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 13;
-                bytes[5] = 13;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_TURN_CCW(uint8_t bytes[], uint8_t  degrees, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 13;
-
-                memcpy(&bytes[5], &degrees, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_MISSION_FLAG_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 23;
-                bytes[5] = 23;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_MISSION_FLAG(uint8_t bytes[], uint8_t  flag)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 23;
-
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_MISSION_BEGIN_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 30;
-                bytes[5] = 30;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_MISSION_BEGIN(uint8_t bytes[], uint8_t  flag)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 30;
-
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
             static uint8_t serialize_FIRMWARE_VERSION_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
@@ -2074,49 +1809,88 @@ namespace hf {
                 return 7;
             }
 
-            static uint8_t serialize_SET_MOSQUITO_VERSION(uint8_t bytes[], uint8_t  version)
+            static uint8_t serialize_ATTITUDE_RADIANS_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 122;
+                bytes[5] = 122;
+
+                return 6;
+            }
+
+            static uint8_t serialize_ATTITUDE_RADIANS(uint8_t bytes[], float  roll, float  pitch, float  yaw)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 12;
+                bytes[4] = 122;
+
+                memcpy(&bytes[5], &roll, sizeof(float));
+                memcpy(&bytes[9], &pitch, sizeof(float));
+                memcpy(&bytes[13], &yaw, sizeof(float));
+
+                bytes[17] = CRC8(&bytes[3], 14);
+
+                return 18;
+            }
+
+            static uint8_t serialize_WP_CHANGE_SPEED_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 10;
+                bytes[5] = 10;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_CHANGE_SPEED(uint8_t bytes[], uint8_t  speed, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 10;
+
+                memcpy(&bytes[5], &speed, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_WP_LAND_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 3;
+                bytes[5] = 3;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_LAND(uint8_t bytes[], uint8_t  code)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 1;
-                bytes[4] = 223;
+                bytes[4] = 3;
 
-                memcpy(&bytes[5], &version, sizeof(uint8_t));
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 
                 return 7;
-            }
-
-            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 64;
-                bytes[4] = 224;
-
-                memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
-                memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));
-                memcpy(&bytes[13], &gyroRollPitchD, sizeof(float));
-                memcpy(&bytes[17], &gyroYawP, sizeof(float));
-                memcpy(&bytes[21], &gyroYawI, sizeof(float));
-                memcpy(&bytes[25], &demandsToRate, sizeof(float));
-                memcpy(&bytes[29], &levelP, sizeof(float));
-                memcpy(&bytes[33], &altHoldP, sizeof(float));
-                memcpy(&bytes[37], &altHoldVelP, sizeof(float));
-                memcpy(&bytes[41], &altHoldVelI, sizeof(float));
-                memcpy(&bytes[45], &altHoldVelD, sizeof(float));
-                memcpy(&bytes[49], &minAltitude, sizeof(float));
-                memcpy(&bytes[53], &param6, sizeof(float));
-                memcpy(&bytes[57], &param7, sizeof(float));
-                memcpy(&bytes[61], &param8, sizeof(float));
-                memcpy(&bytes[65], &param9, sizeof(float));
-
-                bytes[69] = CRC8(&bytes[3], 66);
-
-                return 70;
             }
 
             static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)
@@ -2128,6 +1902,278 @@ namespace hf {
                 bytes[4] = 225;
 
                 memcpy(&bytes[5], &hasBoard, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_DISARM_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 2;
+                bytes[5] = 2;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_DISARM(uint8_t bytes[], uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 2;
+
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_ARM_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 1;
+                bytes[5] = 1;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_ARM(uint8_t bytes[], uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 1;
+
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_GO_BACKWARD_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 6;
+                bytes[5] = 6;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_GO_BACKWARD(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 6;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_FAKE_INT_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 199;
+                bytes[5] = 199;
+
+                return 6;
+            }
+
+            static uint8_t serialize_FAKE_INT(uint8_t bytes[], int32_t  value1, int32_t  value2)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 8;
+                bytes[4] = 199;
+
+                memcpy(&bytes[5], &value1, sizeof(int32_t));
+                memcpy(&bytes[9], &value2, sizeof(int32_t));
+
+                bytes[13] = CRC8(&bytes[3], 10);
+
+                return 14;
+            }
+
+            static uint8_t serialize_ALTITUDE_METERS_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 123;
+                bytes[5] = 123;
+
+                return 6;
+            }
+
+            static uint8_t serialize_ALTITUDE_METERS(uint8_t bytes[], float  estalt, float  vario)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 8;
+                bytes[4] = 123;
+
+                memcpy(&bytes[5], &estalt, sizeof(float));
+                memcpy(&bytes[9], &vario, sizeof(float));
+
+                bytes[13] = CRC8(&bytes[3], 10);
+
+                return 14;
+            }
+
+            static uint8_t serialize_GET_MOTOR_NORMAL_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 124;
+                bytes[5] = 124;
+
+                return 6;
+            }
+
+            static uint8_t serialize_GET_MOTOR_NORMAL(uint8_t bytes[], float  m1, float  m2, float  m3, float  m4)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 16;
+                bytes[4] = 124;
+
+                memcpy(&bytes[5], &m1, sizeof(float));
+                memcpy(&bytes[9], &m2, sizeof(float));
+                memcpy(&bytes[13], &m3, sizeof(float));
+                memcpy(&bytes[17], &m4, sizeof(float));
+
+                bytes[21] = CRC8(&bytes[3], 18);
+
+                return 22;
+            }
+
+            static uint8_t serialize_SET_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 24;
+                bytes[4] = 222;
+
+                memcpy(&bytes[5], &c1, sizeof(float));
+                memcpy(&bytes[9], &c2, sizeof(float));
+                memcpy(&bytes[13], &c3, sizeof(float));
+                memcpy(&bytes[17], &c4, sizeof(float));
+                memcpy(&bytes[21], &c5, sizeof(float));
+                memcpy(&bytes[25], &c6, sizeof(float));
+
+                bytes[29] = CRC8(&bytes[3], 26);
+
+                return 30;
+            }
+
+            static uint8_t serialize_LOITER_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 126;
+                bytes[5] = 126;
+
+                return 6;
+            }
+
+            static uint8_t serialize_LOITER(uint8_t bytes[], float  agl, float  flowx, float  flowy)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 12;
+                bytes[4] = 126;
+
+                memcpy(&bytes[5], &agl, sizeof(float));
+                memcpy(&bytes[9], &flowx, sizeof(float));
+                memcpy(&bytes[13], &flowy, sizeof(float));
+
+                bytes[17] = CRC8(&bytes[3], 14);
+
+                return 18;
+            }
+
+            static uint8_t serialize_WP_CHANGE_ALTITUDE_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 9;
+                bytes[5] = 9;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_CHANGE_ALTITUDE(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 9;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_WP_MISSION_BEGIN_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 30;
+                bytes[5] = 30;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_MISSION_BEGIN(uint8_t bytes[], uint8_t  flag)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 30;
+
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 

--- a/src/sensors/rangefinder.hpp
+++ b/src/sensors/rangefinder.hpp
@@ -40,9 +40,9 @@ namespace hf {
             float _distance;
             
             // Range finder calibration parameters
-            float rx = 0;
-            float ry = 0;
-            float rz = 0;
+            float _rx = 0;
+            float _ry = 0;
+            float _rz = 0;
             
         public:
 
@@ -54,13 +54,13 @@ namespace hf {
             {
               // auxiliary variables to avoid duplicating computations
               float aux1 = x[2]*x[2] - x[3]*x[3] - x[4]*x[4] + x[5]*x[5];
-              float aux2 = rx*(2*x[2]*x[4] - 2*x[3]*x[5]);
-              float aux3 = ry*(2*x[2]*x[3] + 2*x[4]*x[5]);
-              float aux4 = x[0] + rz*aux1 - aux2 + aux3;
-              float aux5 = (2*x[3]*rx + 2*x[4]*ry + 2*x[5]*rz)/aux1 - 2*x[5]*aux4/(aux1*aux1);
-              float aux6 = (2*x[2]*ry - 2*x[3]*rz + 2*x[5]*rx)/aux1 + 2*x[3]*aux4/(aux1*aux1);
-              float aux7 = (2*x[2]*rx + 2*x[4]*rz - 2*x[5]*ry)/aux1 - 2*x[4]*aux4/(aux1*aux1);
-              float aux8 = (2*x[2]*rz + 2*x[3]*ry - 2*x[4]*rx)/aux1 - 2*x[2]*aux4/(aux1*aux1);
+              float aux2 = _rx*(2*x[2]*x[4] - 2*x[3]*x[5]);
+              float aux3 = _ry*(2*x[2]*x[3] + 2*x[4]*x[5]);
+              float aux4 = x[0] + _rz*aux1 - aux2 + aux3;
+              float aux5 = (2*x[3]*_rx + 2*x[4]*_ry + 2*x[5]*_rz)/aux1 - 2*x[5]*aux4/(aux1*aux1);
+              float aux6 = (2*x[2]*_ry - 2*x[3]*_rz + 2*x[5]*_rx)/aux1 + 2*x[3]*aux4/(aux1*aux1);
+              float aux7 = (2*x[2]*_rx + 2*x[4]*_rz - 2*x[5]*_ry)/aux1 - 2*x[4]*aux4/(aux1*aux1);
+              float aux8 = (2*x[2]*_rz + 2*x[3]*_ry - 2*x[4]*_rx)/aux1 - 2*x[2]*aux4/(aux1*aux1);
               // 1 column
               H[0] =  1/aux1;
               // 2 column
@@ -83,7 +83,7 @@ namespace hf {
             {
                 // innovation = measured - predicted
                 // predicted is p_w_r(3)/R*R_r_i(3,3), where R = rotation matrix
-                float predicted = (x[0] + rz*(x[2]*x[2] - x[3]*x[3] - x[4]*x[4] + x[5]*x[5]) - rx*(2*x[2]*x[4] - 2*x[3]*x[5]) + ry*(2*x[2]*x[3] + 2*x[4]*x[5]))/(x[2]*x[2] - x[3]*x[3] - x[4]*x[4] + x[5]*x[5]);;
+                float predicted = (x[0] + _rz*(x[2]*x[2] - x[3]*x[3] - x[4]*x[4] + x[5]*x[5]) - _rx*(2*x[2]*x[4] - 2*x[3]*x[5]) + _ry*(2*x[2]*x[3] + 2*x[4]*x[5]))/(x[2]*x[2] - x[3]*x[3] - x[4]*x[4] + x[5]*x[5]);;
                 z[0] = _distance - predicted;
             }
             
@@ -100,7 +100,14 @@ namespace hf {
                 }
                 invZ[0] = 1.0/Z[0];
                 return 0;
-            }  
+            }
+            
+            void setCalibration(float rx, float ry, float rz)
+            {
+              _rx = rx;
+              _ry = ry;
+              _rz = rz;
+            }
 
         protected:
 


### PR DESCRIPTION
## Feature this PR addresses

This PR enables setting the translation (x, y and z displacement) values (the so called rangefinder calibration parameters) between the IMU frame and range frame via an MSP message. See [here](https://github.com/BonaDrone/documentation/blob/master/extras/scripts/set_params.py) an example of this how can be done.

### Why is this needed?

The rangefinder observation model requires to know both the rotation matrix `R` and the translation `T` between the IMU frame and the range frame to predict measurement values.

We can (and should, because otherwise calculations become quite more complex) assume that both for the mosquito 150 and the mosquito 90 the `R` matrix between frames is the same, and it has been hardcoded into the equations. This is so because both the board and the rangefinder will be mounted in a similar fashion and their relative orientation will be the same in both cases.

However, due to the different dimensions of the Mosquito 90 and Mosquito 150 the translation between frames will surely not be the same. To avoid having to hardcode those values, and in case any of the designs changes in the future, it is worth to be able to set those values via an MSP message. As with the rest of configuration parameters, they will be stored in the EEPROM.

## Current behavior

Rangefinder parameters are hardcoded.

## Expected behavior after merge

Rangefinder parameters are read and loaded from the EEPROM and can be set via MSP.

