### PR TITLE
Implement handler for getting Motor values via MSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Added
 
 * #37 Hackflight Parametrization
+* #46 Implement handler for getting Motor values via MSP
 
 ### Changed
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -408,6 +408,15 @@ namespace hf {
                 EEPROM.put(PID_CONSTANTS + 11 * sizeof(float), minAltitude);
                 
             }
+            
+            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4)
+            {
+                  m1 = _mixer->motorsDisarmed[0];
+                  m2 = _mixer->motorsDisarmed[1];
+                  m3 = _mixer->motorsDisarmed[2];
+                  m4 = _mixer->motorsDisarmed[3];
+            }
+
 
         public:
 


### PR DESCRIPTION
This PR overrides in `hackflight.hpp` the handler to obtain motor values when requested via MSP. Message ID is 124. 