### PR TITLE
MSP getters for Mosquito version and presence of Position Board

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 * #37 Hackflight Parametrization
 * #46 Implement handler for getting Motor values via MSP
+* #47 MSP getters for Mosquito version and presence of Position Board
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -164,6 +164,16 @@
    {"comment": "begin of mission codes flag"},
    {"flag": "byte"}],
 
+  "MOSQUITO_VERSION":
+  [{"ID": 25},
+   {"comment": "Return the type of Mosquito (90 or 150)"},
+   {"mosquitoVersion": "byte"}],
+  
+  "POSITION_BOARD":
+  [{"ID": 26},
+   {"comment": "Return if position board is present"},
+   {"hasPositionBoard": "byte"}],
+
   "WP_MISSION_BEGIN":
   [{"ID": 30},
    {"comment": "Start mission execution"},

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -46,6 +46,8 @@ namespace hf {
 
             // XXX use a proper version formating
             uint8_t _firmwareVersion = 0;
+            bool _isMosquito90;
+            bool _hasPositioningBoard;
 
             // Passed to Hackflight::init() for a particular build
             Board      * _board;
@@ -409,14 +411,23 @@ namespace hf {
                 
             }
             
-            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4)
+            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4) override
             {
                   m1 = _mixer->motorsDisarmed[0];
                   m2 = _mixer->motorsDisarmed[1];
                   m3 = _mixer->motorsDisarmed[2];
                   m4 = _mixer->motorsDisarmed[3];
             }
-
+            
+            virtual void handle_MOSQUITO_VERSION_Request(uint8_t & mosquitoVersion) override
+            {
+                mosquitoVersion = _isMosquito90;
+            }
+            
+            virtual void handle_POSITION_BOARD_Request(uint8_t & hasPositionBoard) override
+            {
+                hasPositionBoard = _hasPositioningBoard;
+            }
 
         public:
 
@@ -466,6 +477,12 @@ namespace hf {
                 _failsafe = false;
 
             } // init
+
+            void setParams(bool hasPositionBoard, bool isMosquito90)
+            {
+                _hasPositioningBoard = hasPositionBoard;
+                _isMosquito90 = isMosquito90;
+            }
 
             void addSensor(PeripheralSensor * sensor) 
             {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -162,6 +162,10 @@ namespace hf {
                     opticalflow.begin();
                     h.addSensor(&opticalflow);                    
                 }
+
+                // Set parameters in hackflight instance so that they can be queried
+                // via MSP
+                h.setParams(_hasPositioningBoard, _isMosquito90);
                 
             } // init
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -626,6 +626,24 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
+                    case 25:
+                    {
+                        uint8_t mosquitoVersion = 0;
+                        handle_MOSQUITO_VERSION_Request(mosquitoVersion);
+                        prepareToSendBytes(1);
+                        sendByte(mosquitoVersion);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 26:
+                    {
+                        uint8_t hasPositionBoard = 0;
+                        handle_POSITION_BOARD_Request(hasPositionBoard);
+                        prepareToSendBytes(1);
+                        sendByte(hasPositionBoard);
+                        serialize8(_checksum);
+                        } break;
+
                     case 30:
                     {
                         uint8_t flag = 0;
@@ -885,6 +903,18 @@ namespace hf {
                     {
                         uint8_t flag = getArgument(0);
                         handle_WP_MISSION_FLAG_Data(flag);
+                        } break;
+
+                    case 25:
+                    {
+                        uint8_t mosquitoVersion = getArgument(0);
+                        handle_MOSQUITO_VERSION_Data(mosquitoVersion);
+                        } break;
+
+                    case 26:
+                    {
+                        uint8_t hasPositionBoard = getArgument(0);
+                        handle_POSITION_BOARD_Data(hasPositionBoard);
                         } break;
 
                     case 30:
@@ -1242,6 +1272,26 @@ namespace hf {
             virtual void handle_WP_MISSION_FLAG_Data(uint8_t & flag)
             {
                 (void)flag;
+            }
+
+            virtual void handle_MOSQUITO_VERSION_Request(uint8_t & mosquitoVersion)
+            {
+                (void)mosquitoVersion;
+            }
+
+            virtual void handle_MOSQUITO_VERSION_Data(uint8_t & mosquitoVersion)
+            {
+                (void)mosquitoVersion;
+            }
+
+            virtual void handle_POSITION_BOARD_Request(uint8_t & hasPositionBoard)
+            {
+                (void)hasPositionBoard;
+            }
+
+            virtual void handle_POSITION_BOARD_Data(uint8_t & hasPositionBoard)
+            {
+                (void)hasPositionBoard;
             }
 
             virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag)
@@ -2014,6 +2064,60 @@ namespace hf {
                 bytes[4] = 23;
 
                 memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_MOSQUITO_VERSION_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 25;
+                bytes[5] = 25;
+
+                return 6;
+            }
+
+            static uint8_t serialize_MOSQUITO_VERSION(uint8_t bytes[], uint8_t  mosquitoVersion)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 25;
+
+                memcpy(&bytes[5], &mosquitoVersion, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_POSITION_BOARD_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 26;
+                bytes[5] = 26;
+
+                return 6;
+            }
+
+            static uint8_t serialize_POSITION_BOARD(uint8_t bytes[], uint8_t  hasPositionBoard)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 26;
+
+                memcpy(&bytes[5], &hasPositionBoard, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 


### PR DESCRIPTION
This PR adds two new MSP messages. This are:

`MOSQUITO_VERSION`, with ID 25, which acts as a getter for the type of Mosquito the board is mounted on. A return value of 0 is Mosquito 150 and a return value of 1 is Mosquito 90.

`POSITION_BOARD`, with ID 26, which acts as a getter for the presence of positioning board. A return value of 1 means that the Position Board is present and a return value of 0 means that it is not present.