### PR TITLE
Add MSP message and methods to calibrate ESCs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * #37 Hackflight Parametrization
 * #46 Implement handler for getting Motor values via MSP
 * #47 MSP getters for Mosquito version and presence of Position Board
+* #48 MSP message and methods to calibrate ESCs
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -164,6 +164,11 @@
    {"comment": "begin of mission codes flag"},
    {"flag": "byte"}],
 
+  "ESC_CALIBRATION":
+  [{"ID": 24},
+   {"comment": "Calibrate the ESCs with the Standard or MultiShot protocol"},
+   {"protocol": "byte"}],
+
   "MOSQUITO_VERSION":
   [{"ID": 25},
    {"comment": "Return the type of Mosquito (90 or 150)"},

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -68,6 +68,9 @@ namespace hf {
 
             //------------------------------- Reboot for non-Arduino boards ---------------------------------------------
             virtual void reboot(void) { }
+            
+            //------------------------------------ ESCs calibration ------------------------------------------------------
+            virtual void calibrateESCs(void) { }
 
             //----------------------------------------- Safety -----------------------------------------------------------
             virtual void showArmedStatus(bool armed) { (void)armed; }

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -169,6 +169,53 @@ namespace hf {
                     analogWrite(MOTOR_PINS[k], PWM_MIN>>3);
                 }
             }
+            
+            virtual void calibrateESCs(void) override
+            {
+                // PWM Values
+                uint16_t BASELINE = 1000;
+                uint16_t MIDVAL   = 1500;
+                uint16_t MAXVAL   = 2000;
+
+                uint8_t LED_R = 25;
+                uint8_t LED_G = 26;
+                uint8_t LED_B = 38;
+
+                pinMode(LED_R, OUTPUT);  
+                pinMode(LED_G, OUTPUT);
+                pinMode(LED_B, OUTPUT);
+
+                digitalWrite(LED_R, HIGH);
+                digitalWrite(LED_G, HIGH);
+                digitalWrite(LED_B, HIGH);
+  
+                digitalWrite(LED_R, LOW);
+                delay(500);
+                digitalWrite(LED_R, HIGH);
+                digitalWrite(LED_G, LOW);
+                delay(500);
+                digitalWrite(LED_G, HIGH);
+                digitalWrite(LED_B, LOW);
+                delay(500);
+  
+                // Blue LED ON when calibrating (first part)
+                for (int k=0; k<4; ++k)
+                {
+                    pinMode(MOTOR_PINS[k], OUTPUT);    
+                    analogWrite(MOTOR_PINS[k], MAXVAL >> 3);
+                }
+                delay(10000);
+                digitalWrite(LED_B, HIGH);
+  
+                // Green LED ON when calibrating (second part)
+                digitalWrite(LED_G, LOW);
+                for (int k=0; k<4; ++k)
+                {
+                    analogWrite(MOTOR_PINS[k], BASELINE >> 3);
+                }
+                delay(10000);
+                digitalWrite(LED_G, HIGH);
+            }
 
     }; // class BonadroneStandard
 
@@ -199,6 +246,55 @@ namespace hf {
                     analogWriteRange(MOTOR_PINS[k], 10000);
                     analogWrite(MOTOR_PINS[k], PWM_MIN);
                 }
+            }
+            
+            virtual void calibrateESCs(void) override
+            {
+                // PWM Values
+                uint16_t BASELINE = 100;
+                uint16_t MAXVAL   = 500;
+                uint8_t LED_R = 25;
+                uint8_t LED_G = 26;
+                uint8_t LED_B = 38;
+    
+                pinMode(LED_R, OUTPUT);  
+                pinMode(LED_G, OUTPUT);
+                pinMode(LED_B, OUTPUT);
+                
+                // LED sequence that signals begin of calibration
+                digitalWrite(LED_R, HIGH);
+                digitalWrite(LED_G, HIGH);
+                digitalWrite(LED_B, HIGH);
+
+                digitalWrite(LED_R, LOW);
+                delay(500);
+                digitalWrite(LED_R, HIGH);
+                digitalWrite(LED_G, LOW);
+                delay(500);
+                digitalWrite(LED_G, HIGH);
+                digitalWrite(LED_B, LOW);
+                delay(500);
+
+                // Blue LED ON when calibrating (first part)
+                for (int k=0; k<4; ++k)
+                {
+                    pinMode(MOTOR_PINS[k], OUTPUT);
+                    analogWriteFrequency(MOTOR_PINS[k], 2000);
+                    analogWriteRange(MOTOR_PINS[k], 10000);
+                    analogWrite(MOTOR_PINS[k], MAXVAL);
+                }
+
+                delay(10000);
+                digitalWrite(LED_B, HIGH);
+
+                // Green LED ON when calibrating (second part)
+                digitalWrite(LED_G, LOW);
+                for (int k=0; k<4; ++k)
+                {
+                    analogWrite(MOTOR_PINS[k], BASELINE);
+                }
+                delay(10000);
+                digitalWrite(LED_G, HIGH);
             }
 
     }; // class BonadroneMultiShot

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -298,6 +298,13 @@ namespace hf {
                 }
             }
 
+            virtual void handle_ESC_CALIBRATION_Request(uint8_t & protocol)
+            {
+                (void)protocol;
+                _board->calibrateESCs();
+            }
+
+
             virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6) override
             {
                 c1 = _receiver->getRawval(0);

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -626,6 +626,15 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
+                    case 24:
+                    {
+                        uint8_t protocol = 0;
+                        handle_ESC_CALIBRATION_Request(protocol);
+                        prepareToSendBytes(1);
+                        sendByte(protocol);
+                        serialize8(_checksum);
+                        } break;
+
                     case 25:
                     {
                         uint8_t mosquitoVersion = 0;
@@ -903,6 +912,12 @@ namespace hf {
                     {
                         uint8_t flag = getArgument(0);
                         handle_WP_MISSION_FLAG_Data(flag);
+                        } break;
+
+                    case 24:
+                    {
+                        uint8_t protocol = getArgument(0);
+                        handle_ESC_CALIBRATION_Data(protocol);
                         } break;
 
                     case 25:
@@ -1272,6 +1287,16 @@ namespace hf {
             virtual void handle_WP_MISSION_FLAG_Data(uint8_t & flag)
             {
                 (void)flag;
+            }
+
+            virtual void handle_ESC_CALIBRATION_Request(uint8_t & protocol)
+            {
+                (void)protocol;
+            }
+
+            virtual void handle_ESC_CALIBRATION_Data(uint8_t & protocol)
+            {
+                (void)protocol;
             }
 
             virtual void handle_MOSQUITO_VERSION_Request(uint8_t & mosquitoVersion)
@@ -2064,6 +2089,33 @@ namespace hf {
                 bytes[4] = 23;
 
                 memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_ESC_CALIBRATION_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 24;
+                bytes[5] = 24;
+
+                return 6;
+            }
+
+            static uint8_t serialize_ESC_CALIBRATION(uint8_t bytes[], uint8_t  protocol)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 24;
+
+                memcpy(&bytes[5], &protocol, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 


### PR DESCRIPTION
This PR adds:
1. A message to trigger ESCs calibration
2. The methods that calibrate the ESCs with the protocol that the board instance expects.