### PR TITLE
Fix Optical Flow pin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,4 +16,4 @@
 ### Fixed
 
 * #39 Firmware version
-
+* #49 Optical Flow connection pin

--- a/src/sensors/opticalflow.hpp
+++ b/src/sensors/opticalflow.hpp
@@ -37,7 +37,7 @@ namespace hf {
             static constexpr float UPDATE_PERIOD = .01f;
 
             // Use digital pin 10 for chip select
-            PMW3901 _flowSensor = PMW3901(A4, &SPI1);
+            PMW3901 _flowSensor = PMW3901(12, &SPI1);
 
             // Track elapsed time for periodic readiness
             bool _previousTime = 0;


### PR DESCRIPTION
This PR solves a mismatch in the Optical Flow connection pin specified in the code and the real pin actually used. 