### PR TITLE
Check if position board is connected via MSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * #46 Implement handler for getting Motor values via MSP
 * #47 MSP getters for Mosquito version and presence of Position Board
 * #48 MSP message and methods to calibrate ESCs
+* #50 Check if position board is connected via MSP
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -182,7 +182,7 @@
   "POSITION_BOARD_CONNECTED":
   [{"ID": 27},
    {"comment": "Return if position board is connected"},
-   {"hasPositionBoard": "byte"}],
+   {"positionBoardConnected": "byte"}],
 
   "WP_MISSION_BEGIN":
   [{"ID": 30},

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -176,7 +176,12 @@
   
   "POSITION_BOARD":
   [{"ID": 26},
-   {"comment": "Return if position board is present"},
+   {"comment": "Return if position board parameter is set to True or False"},
+   {"hasPositionBoard": "byte"}],
+
+  "POSITION_BOARD_CONNECTED":
+  [{"ID": 27},
+   {"comment": "Return if position board is connected"},
    {"hasPositionBoard": "byte"}],
 
   "WP_MISSION_BEGIN":

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -48,6 +48,7 @@ namespace hf {
             uint8_t _firmwareVersion = 0;
             bool _isMosquito90;
             bool _hasPositioningBoard;
+            bool _positionBoardConnected;
 
             // Passed to Hackflight::init() for a particular build
             Board      * _board;
@@ -435,6 +436,12 @@ namespace hf {
             {
                 hasPositionBoard = _hasPositioningBoard;
             }
+            
+            virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & positionBoardConnected) override
+            {
+                positionBoardConnected = _positionBoardConnected;
+            }
+
 
         public:
 
@@ -485,10 +492,11 @@ namespace hf {
 
             } // init
 
-            void setParams(bool hasPositionBoard, bool isMosquito90)
+            void setParams(bool hasPositionBoard, bool isMosquito90, bool positionBoardConnected)
             {
                 _hasPositioningBoard = hasPositionBoard;
                 _isMosquito90 = isMosquito90;
+                _positionBoardConnected = positionBoardConnected;
             }
 
             void addSensor(PeripheralSensor * sensor) 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -56,6 +56,8 @@ namespace hf {
               // Params
               bool _hasPositioningBoard = false;
               bool _isMosquito90 = false;
+              // Connection status (false unless proven otherwise)
+              bool _positionBoardConnected = false;
               // Rate PID params
               float _gyroRollPitchP;
               float _gyroRollPitchI;
@@ -155,17 +157,19 @@ namespace hf {
                 if (_hasPositioningBoard)
                 {
                     hf::VL53L1X_Rangefinder rangefinder;
-                    rangefinder.begin();
+                    bool _rangeConnected = rangefinder.begin();
                     h.addSensor(&rangefinder);
                     
                     hf::OpticalFlow opticalflow;
-                    opticalflow.begin();
-                    h.addSensor(&opticalflow);                    
+                    bool _opticalConnected = opticalflow.begin();
+                    h.addSensor(&opticalflow);
+                    
+                    _positionBoardConnected = _rangeConnected & _opticalConnected;                 
                 }
 
                 // Set parameters in hackflight instance so that they can be queried
                 // via MSP
-                h.setParams(_hasPositioningBoard, _isMosquito90);
+                h.setParams(_hasPositioningBoard, _isMosquito90, _positionBoardConnected);
                 
             } // init
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -655,10 +655,10 @@ namespace hf {
 
                     case 27:
                     {
-                        uint8_t hasPositionBoard = 0;
-                        handle_POSITION_BOARD_CONNECTED_Request(hasPositionBoard);
+                        uint8_t positionBoardConnected = 0;
+                        handle_POSITION_BOARD_CONNECTED_Request(positionBoardConnected);
                         prepareToSendBytes(1);
-                        sendByte(hasPositionBoard);
+                        sendByte(positionBoardConnected);
                         serialize8(_checksum);
                         } break;
 
@@ -943,8 +943,8 @@ namespace hf {
 
                     case 27:
                     {
-                        uint8_t hasPositionBoard = getArgument(0);
-                        handle_POSITION_BOARD_CONNECTED_Data(hasPositionBoard);
+                        uint8_t positionBoardConnected = getArgument(0);
+                        handle_POSITION_BOARD_CONNECTED_Data(positionBoardConnected);
                         } break;
 
                     case 30:
@@ -1334,14 +1334,14 @@ namespace hf {
                 (void)hasPositionBoard;
             }
 
-            virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & hasPositionBoard)
+            virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & positionBoardConnected)
             {
-                (void)hasPositionBoard;
+                (void)positionBoardConnected;
             }
 
-            virtual void handle_POSITION_BOARD_CONNECTED_Data(uint8_t & hasPositionBoard)
+            virtual void handle_POSITION_BOARD_CONNECTED_Data(uint8_t & positionBoardConnected)
             {
-                (void)hasPositionBoard;
+                (void)positionBoardConnected;
             }
 
             virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag)
@@ -2213,7 +2213,7 @@ namespace hf {
                 return 6;
             }
 
-            static uint8_t serialize_POSITION_BOARD_CONNECTED(uint8_t bytes[], uint8_t  hasPositionBoard)
+            static uint8_t serialize_POSITION_BOARD_CONNECTED(uint8_t bytes[], uint8_t  positionBoardConnected)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
@@ -2221,7 +2221,7 @@ namespace hf {
                 bytes[3] = 1;
                 bytes[4] = 27;
 
-                memcpy(&bytes[5], &hasPositionBoard, sizeof(uint8_t));
+                memcpy(&bytes[5], &positionBoardConnected, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -653,6 +653,15 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
+                    case 27:
+                    {
+                        uint8_t hasPositionBoard = 0;
+                        handle_POSITION_BOARD_CONNECTED_Request(hasPositionBoard);
+                        prepareToSendBytes(1);
+                        sendByte(hasPositionBoard);
+                        serialize8(_checksum);
+                        } break;
+
                     case 30:
                     {
                         uint8_t flag = 0;
@@ -930,6 +939,12 @@ namespace hf {
                     {
                         uint8_t hasPositionBoard = getArgument(0);
                         handle_POSITION_BOARD_Data(hasPositionBoard);
+                        } break;
+
+                    case 27:
+                    {
+                        uint8_t hasPositionBoard = getArgument(0);
+                        handle_POSITION_BOARD_CONNECTED_Data(hasPositionBoard);
                         } break;
 
                     case 30:
@@ -1315,6 +1330,16 @@ namespace hf {
             }
 
             virtual void handle_POSITION_BOARD_Data(uint8_t & hasPositionBoard)
+            {
+                (void)hasPositionBoard;
+            }
+
+            virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & hasPositionBoard)
+            {
+                (void)hasPositionBoard;
+            }
+
+            virtual void handle_POSITION_BOARD_CONNECTED_Data(uint8_t & hasPositionBoard)
             {
                 (void)hasPositionBoard;
             }
@@ -2168,6 +2193,33 @@ namespace hf {
                 bytes[2] = 62;
                 bytes[3] = 1;
                 bytes[4] = 26;
+
+                memcpy(&bytes[5], &hasPositionBoard, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_POSITION_BOARD_CONNECTED_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 27;
+                bytes[5] = 27;
+
+                return 6;
+            }
+
+            static uint8_t serialize_POSITION_BOARD_CONNECTED(uint8_t bytes[], uint8_t  hasPositionBoard)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 27;
 
                 memcpy(&bytes[5], &hasPositionBoard, sizeof(uint8_t));
 

--- a/src/sensors/opticalflow.hpp
+++ b/src/sensors/opticalflow.hpp
@@ -69,15 +69,13 @@ namespace hf {
 
         public:
 
-            void begin(void)
+            bool begin(void)
             {
+                bool connected = true;
                 if (!_flowSensor.begin()) {
-                    while (true) {
-                        Serial.println("Initialization of the flow sensor failed");
-                        delay(500);
-                    }
+                  connected = false;
                 }
-
+                return connected;
             }
 
     };  // class OpticalFlow 

--- a/src/sensors/rangefinders/vl53l1x.hpp
+++ b/src/sensors/rangefinders/vl53l1x.hpp
@@ -44,9 +44,13 @@ namespace hf {
 
         public:
 
-            void begin(void)
+            bool begin(void)
             {
-                _distanceSensor.begin();
+                bool connected = true;
+                if (!_distanceSensor.begin()) {
+                  connected = false;
+                }
+                return connected;
             }
 
     }; // class VL53L1X_Rangefinder 


### PR DESCRIPTION
This PR enables to check if the position board is connected via an MSP request (ID: 27).

To do so, the `begin` methods of the rangefinder and optical flow have been modified to return boolean values. If they return `true` it means that the sensor is connected. Otherwise, they return `false`. If both of them return `true` then the `_positionBoardConnected` attribute (`false` by default) of the `HackflightWrapper` class gets set to `true`. This value is what gets sent via MSP when the request to check if the position board is connected is received.