### PR TITLE
Modify parameters at runtime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,3 +18,4 @@
 
 * #39 Firmware version
 * #49 Optical Flow connection pin
+* #51 Modify parameters at runtime (Mosquito version and Position Board presence)

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -381,8 +381,10 @@ namespace hf {
                 if (version)
                 {
                   EEPROM.put(GENERAL_CONFIG, config | (1 << MOSQUITO_VERSION));
+                  _isMosquito90 = true;
                 } else {
                   EEPROM.put(GENERAL_CONFIG, config & ~(1 << MOSQUITO_VERSION));
+                  _isMosquito90 = false;
                 }
             }
             
@@ -392,8 +394,10 @@ namespace hf {
                 if (hasBoard)
                 {
                   EEPROM.put(GENERAL_CONFIG, config | (1 << POSITIONING_BOARD));
+                  _hasPositioningBoard = true;
                 } else {
                   EEPROM.put(GENERAL_CONFIG, config & ~(1 << POSITIONING_BOARD));
+                  _hasPositioningBoard = false;
                 }
             }
             


### PR DESCRIPTION
## Issue/Feature this PR addresses

When a set of either of the parameters:
a) Mosquito version
b) Positioning Board presence
is performed at runtime, the variables that store the value of the parameters are not updated. Only the respective EEPROM address is modified. This means that changes in these parameters at runtime are not effective until the board is unplugged and plugged again.

## Current behavior

Modifying the parameters:
a) Mosquito version
b) Positioning Board presence
is not effective until the board is disconnected and connected again.

## Expected behavior after merge

Modifying the parameters:
a) Mosquito version
b) Positioning Board presence
has an immediate effect