### PR TITLE
Fix ESC calibration procedure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,3 +19,4 @@
 * #39 Firmware version
 * #49 Optical Flow connection pin
 * #51 Modify parameters at runtime (Mosquito version and Position Board presence)
+* #52 ESC calibration procedure

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -68,9 +68,6 @@ namespace hf {
 
             //------------------------------- Reboot for non-Arduino boards ---------------------------------------------
             virtual void reboot(void) { }
-            
-            //------------------------------------ ESCs calibration ------------------------------------------------------
-            virtual void calibrateESCs(void) { }
 
             //----------------------------------------- Safety -----------------------------------------------------------
             virtual void showArmedStatus(bool armed) { (void)armed; }

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -169,53 +169,6 @@ namespace hf {
                     analogWrite(MOTOR_PINS[k], PWM_MIN>>3);
                 }
             }
-            
-            virtual void calibrateESCs(void) override
-            {
-                // PWM Values
-                uint16_t BASELINE = 1000;
-                uint16_t MIDVAL   = 1500;
-                uint16_t MAXVAL   = 2000;
-
-                uint8_t LED_R = 25;
-                uint8_t LED_G = 26;
-                uint8_t LED_B = 38;
-
-                pinMode(LED_R, OUTPUT);  
-                pinMode(LED_G, OUTPUT);
-                pinMode(LED_B, OUTPUT);
-
-                digitalWrite(LED_R, HIGH);
-                digitalWrite(LED_G, HIGH);
-                digitalWrite(LED_B, HIGH);
-  
-                digitalWrite(LED_R, LOW);
-                delay(500);
-                digitalWrite(LED_R, HIGH);
-                digitalWrite(LED_G, LOW);
-                delay(500);
-                digitalWrite(LED_G, HIGH);
-                digitalWrite(LED_B, LOW);
-                delay(500);
-  
-                // Blue LED ON when calibrating (first part)
-                for (int k=0; k<4; ++k)
-                {
-                    pinMode(MOTOR_PINS[k], OUTPUT);    
-                    analogWrite(MOTOR_PINS[k], MAXVAL >> 3);
-                }
-                delay(10000);
-                digitalWrite(LED_B, HIGH);
-  
-                // Green LED ON when calibrating (second part)
-                digitalWrite(LED_G, LOW);
-                for (int k=0; k<4; ++k)
-                {
-                    analogWrite(MOTOR_PINS[k], BASELINE >> 3);
-                }
-                delay(10000);
-                digitalWrite(LED_G, HIGH);
-            }
 
     }; // class BonadroneStandard
 
@@ -236,7 +189,6 @@ namespace hf {
                 analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)));
             }
 
-
         public:
 
             BonadroneMultiShot(void) : Bonadrone()
@@ -246,55 +198,6 @@ namespace hf {
                     analogWriteRange(MOTOR_PINS[k], 10000);
                     analogWrite(MOTOR_PINS[k], PWM_MIN);
                 }
-            }
-            
-            virtual void calibrateESCs(void) override
-            {
-                // PWM Values
-                uint16_t BASELINE = 100;
-                uint16_t MAXVAL   = 500;
-                uint8_t LED_R = 25;
-                uint8_t LED_G = 26;
-                uint8_t LED_B = 38;
-    
-                pinMode(LED_R, OUTPUT);  
-                pinMode(LED_G, OUTPUT);
-                pinMode(LED_B, OUTPUT);
-                
-                // LED sequence that signals begin of calibration
-                digitalWrite(LED_R, HIGH);
-                digitalWrite(LED_G, HIGH);
-                digitalWrite(LED_B, HIGH);
-
-                digitalWrite(LED_R, LOW);
-                delay(500);
-                digitalWrite(LED_R, HIGH);
-                digitalWrite(LED_G, LOW);
-                delay(500);
-                digitalWrite(LED_G, HIGH);
-                digitalWrite(LED_B, LOW);
-                delay(500);
-
-                // Blue LED ON when calibrating (first part)
-                for (int k=0; k<4; ++k)
-                {
-                    pinMode(MOTOR_PINS[k], OUTPUT);
-                    analogWriteFrequency(MOTOR_PINS[k], 2000);
-                    analogWriteRange(MOTOR_PINS[k], 10000);
-                    analogWrite(MOTOR_PINS[k], MAXVAL);
-                }
-
-                delay(10000);
-                digitalWrite(LED_B, HIGH);
-
-                // Green LED ON when calibrating (second part)
-                digitalWrite(LED_G, LOW);
-                for (int k=0; k<4; ++k)
-                {
-                    analogWrite(MOTOR_PINS[k], BASELINE);
-                }
-                delay(10000);
-                digitalWrite(LED_G, HIGH);
             }
 
     }; // class BonadroneMultiShot

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -45,10 +45,12 @@ namespace hf {
         private: 
 
             // XXX use a proper version formating
-            uint8_t _firmwareVersion = 0;
+            uint8_t _firmwareVersion = 1;
             bool _isMosquito90;
             bool _hasPositioningBoard;
             bool _positionBoardConnected;
+            
+            bool _ESCsCalibrated = false;
 
             // Passed to Hackflight::init() for a particular build
             Board      * _board;
@@ -301,8 +303,12 @@ namespace hf {
 
             virtual void handle_ESC_CALIBRATION_Request(uint8_t & protocol)
             {
-                (void)protocol;
-                _board->calibrateESCs();
+                protocol = 1;
+                if (!_ESCsCalibrated)
+                {
+                  _ESCsCalibrated = true;
+                  _board->calibrateESCs();
+                }
             }
 
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -49,8 +49,6 @@ namespace hf {
             bool _isMosquito90;
             bool _hasPositioningBoard;
             bool _positionBoardConnected;
-            
-            bool _ESCsCalibrated = false;
 
             // Passed to Hackflight::init() for a particular build
             Board      * _board;
@@ -287,6 +285,7 @@ namespace hf {
             // booleans values are stored as the bits of the byte at address 0
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
+            static const uint8_t CALIBRATE_ESC     = 2;
 
 
             virtual void handle_SET_ARMED_Request(uint8_t  flag)
@@ -303,14 +302,9 @@ namespace hf {
 
             virtual void handle_ESC_CALIBRATION_Request(uint8_t & protocol)
             {
-                protocol = 1;
-                if (!_ESCsCalibrated)
-                {
-                  _ESCsCalibrated = true;
-                  _board->calibrateESCs();
-                }
+                uint8_t config = EEPROM.read(GENERAL_CONFIG);
+                EEPROM.put(GENERAL_CONFIG, config | (1 << CALIBRATE_ESC));
             }
-
 
             virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6) override
             {

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -56,6 +56,7 @@ namespace hf {
               // Params
               bool _hasPositioningBoard = false;
               bool _isMosquito90 = false;
+              bool _calibrateESC = false;
               // Connection status (false unless proven otherwise)
               bool _positionBoardConnected = false;
               // Rate PID params
@@ -74,8 +75,7 @@ namespace hf {
               float _altHoldVelD;
               float _minAltitude;
 
-
-              // Required objects to run Hackflight 
+              // Required objects to run Hackflight
               hf::Hackflight h;
               hf::MixerQuadX mixer;
               hf::SBUS_Receiver rc = hf::SBUS_Receiver(CHANNEL_MAP, SERIAL_SBUS, &SBUS_SERIAL);
@@ -88,6 +88,7 @@ namespace hf {
                   uint8_t config = EEPROM.read(GENERAL_CONFIG);
                   _isMosquito90 = (config >> MOSQUITO_VERSION) & 1;
                   _hasPositioningBoard = (config >> POSITIONING_BOARD) & 1;
+                  _calibrateESC = (config >> CALIBRATE_ESC) & 1;
                   // Load Rate PID parameters (each float is 4 bytes)
                   EEPROM.get(PID_CONSTANTS, _gyroRollPitchP);
                   EEPROM.get(PID_CONSTANTS + 1 * sizeof(float), _gyroRollPitchI);
@@ -102,6 +103,108 @@ namespace hf {
                   EEPROM.put(PID_CONSTANTS + 10 * sizeof(float), _altHoldVelD);
                   EEPROM.put(PID_CONSTANTS + 11 * sizeof(float), _minAltitude);
                   
+              }
+              
+              void calibrateESCsStandard(void)
+              {
+                  // Motor pins
+                  int MOTOR_PINS[4] = {3, 4, 5, 6};
+                
+                  // PWM Values
+                  uint16_t BASELINE = 1000;
+                  uint16_t MIDVAL   = 1500;
+                  uint16_t MAXVAL   = 2000;
+
+                  uint8_t LED_R = 25;
+                  uint8_t LED_G = 26;
+                  uint8_t LED_B = 38;
+
+                  pinMode(LED_R, OUTPUT);  
+                  pinMode(LED_G, OUTPUT);
+                  pinMode(LED_B, OUTPUT);
+
+                  digitalWrite(LED_R, HIGH);
+                  digitalWrite(LED_G, HIGH);
+                  digitalWrite(LED_B, HIGH);
+    
+                  digitalWrite(LED_R, LOW);
+                  delay(500);
+                  digitalWrite(LED_R, HIGH);
+                  digitalWrite(LED_G, LOW);
+                  delay(500);
+                  digitalWrite(LED_G, HIGH);
+                  digitalWrite(LED_B, LOW);
+                  delay(500);
+    
+                  // Blue LED ON when calibrating (first part)
+                  for (int k=0; k<4; ++k)
+                  {
+                      pinMode(MOTOR_PINS[k], OUTPUT);    
+                      analogWrite(MOTOR_PINS[k], MAXVAL >> 3);
+                  }
+                  delay(10000);
+                  digitalWrite(LED_B, HIGH);
+    
+                  // Green LED ON when calibrating (second part)
+                  digitalWrite(LED_G, LOW);
+                  for (int k=0; k<4; ++k)
+                  {
+                      analogWrite(MOTOR_PINS[k], BASELINE >> 3);
+                  }
+                  delay(10000);
+                  digitalWrite(LED_G, HIGH);
+              }
+
+              void calibrateESCsMultiShot(void)
+              {
+                  // Motor pins
+                  int MOTOR_PINS[4] = {3, 4, 5, 6};
+
+                  // PWM Values
+                  uint16_t BASELINE = 100;
+                  uint16_t MAXVAL   = 500;
+                  uint8_t LED_R = 25;
+                  uint8_t LED_G = 26;
+                  uint8_t LED_B = 38;
+      
+                  pinMode(LED_R, OUTPUT);  
+                  pinMode(LED_G, OUTPUT);
+                  pinMode(LED_B, OUTPUT);
+                  
+                  // LED sequence that signals begin of calibration
+                  digitalWrite(LED_R, HIGH);
+                  digitalWrite(LED_G, HIGH);
+                  digitalWrite(LED_B, HIGH);
+
+                  digitalWrite(LED_R, LOW);
+                  delay(500);
+                  digitalWrite(LED_R, HIGH);
+                  digitalWrite(LED_G, LOW);
+                  delay(500);
+                  digitalWrite(LED_G, HIGH);
+                  digitalWrite(LED_B, LOW);
+                  delay(500);
+
+                  // Blue LED ON when calibrating (first part)
+                  for (int k=0; k<4; ++k)
+                  {
+                      pinMode(MOTOR_PINS[k], OUTPUT);
+                      analogWriteFrequency(MOTOR_PINS[k], 2000);
+                      analogWriteRange(MOTOR_PINS[k], 10000);
+                      analogWrite(MOTOR_PINS[k], MAXVAL);
+                  }
+
+                  delay(10000);
+                  digitalWrite(LED_B, HIGH);
+
+                  // Green LED ON when calibrating (second part)
+                  digitalWrite(LED_G, LOW);
+                  for (int k=0; k<4; ++k)
+                  {
+                      analogWrite(MOTOR_PINS[k], BASELINE);
+                  }
+                  delay(10000);
+                  digitalWrite(LED_G, HIGH);
               }
 
         protected:
@@ -151,6 +254,14 @@ namespace hf {
                 if (_isMosquito90) {
                     h.init(new hf::BonadroneBrushed(), &rc, &mixer, &ratePid);
                 } else {
+                    if (_calibrateESC)
+                    {
+                      calibrateESCsMultiShot();
+                      uint8_t config = EEPROM.read(GENERAL_CONFIG);
+                      Serial.println(config);
+                      EEPROM.put(GENERAL_CONFIG, config & ~(1 << CALIBRATE_ESC));
+                      Serial.println(config);
+                    }
                     h.init(new hf::BonadroneMultiShot(), &rc, &mixer, &ratePid);
                 }
                 // Add additional sensors


### PR DESCRIPTION
## Feature/issue this PR addresses

This PR fixes ESC calibration through MSP. There was a conflict of interests that prevented a successful calibration when receiving the appropriate message. The problem is that the required procedure to calibrate the ESCs is:

1. Send via PWM and to the ESC the maximum value of the protocol to be used. As an example, for the MultiShot protocol, this value is 500. This makes the ESC enter into programming mode and know the maximum allowed value. The key point here is that **this signal is the first signal that the ESC must receive after connecting it to the battery**.
2. Send via PWM and to the ESC the minimum value of the protocol to be used. As an example, for the MultiShot protocol, this value is 100. This lets the ESC know the protocol to be used and which is the minimum value.

However, when wanting to fly, the message that has to be sent to the ESCs is the minimum value of the protocol to be used. This PWM signal is sent at the constructor of the board class.

https://github.com/BonaDrone/Hackflight/blob/06fe35f618ebedb435cff61db9bef9515d851366/src/boards/bonadrone.hpp#L195-L202

After this call, it is not possible to calibrate the ESCs because the first signal that the ESCs have received is not the maximum value of the protocol to be used. Furthermore, it does not make sense to remove this call to other place just in case the ESCs are to be calibrated.We do not know in advance if the user will want to calibrate the ESCs. 

The suggested solution is as follows: upon receiving the MSP message that forces ESC calibration a bit is set in the EEPROM memory that indicates that the ESCs are to be calibrated. The next time the board is powered up and the battery connected this bit will be read before initializing the board classs. If the bit is set, the calibration of the ESCs will begin.

## Current behavior

ESCs calibration is not successful when receiving the appropriate message.

## Expected behavior after merge

Changing a little the required procedure, the ESCs calibration can be triggered with an MSP message.
