### PR TITLE
Enable setting LEDs on and off with an MSP message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * #47 MSP getters for Mosquito version and presence of Position Board
 * #48 MSP message and methods to calibrate ESCs
 * #50 Check if position board is connected via MSP
+* #55 Enable setting LEDs on/off with an MSP message
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -222,6 +222,13 @@
   "SET_POSITIONING_BOARD":
   [{"ID": 225},
    {"comment": "Specify whether the positioning board is present or not"},
-   {"hasBoard": "byte"}]
+   {"hasBoard": "byte"}],
+   
+  "SET_LEDS":
+  [{"ID": 227},
+   {"comment": "Specify whether the positioning board is present or not"},
+   {"red": "byte"},
+   {"green": "byte"},
+   {"blue": "byte"}]
 
 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -306,6 +306,17 @@ namespace hf {
                 EEPROM.put(GENERAL_CONFIG, config | (1 << CALIBRATE_ESC));
             }
 
+            virtual void handle_SET_LEDS_Request(uint8_t  red, uint8_t  green, uint8_t  blue) override
+            {
+                // XXX Do not store led pins as hardcoded values
+                pinMode(25, OUTPUT);
+                pinMode(26, OUTPUT);
+                pinMode(38, OUTPUT);
+                red ? digitalWrite(25, LOW) : digitalWrite(25, HIGH);
+                green ? digitalWrite(26, LOW) : digitalWrite(26, HIGH);
+                blue ? digitalWrite(38, LOW) : digitalWrite(38, HIGH);
+            }
+
             virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6) override
             {
                 c1 = _receiver->getRawval(0);

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -752,6 +752,21 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 227:
+                    {
+                        uint8_t red = 0;
+                        memcpy(&red,  &_inBuf[0], sizeof(uint8_t));
+
+                        uint8_t green = 0;
+                        memcpy(&green,  &_inBuf[1], sizeof(uint8_t));
+
+                        uint8_t blue = 0;
+                        memcpy(&blue,  &_inBuf[2], sizeof(uint8_t));
+
+                        handle_SET_LEDS_Request(red, green, blue);
+                        acknowledgeResponse();
+                        } break;
+
                 }
             }
 
@@ -1422,6 +1437,20 @@ namespace hf {
             virtual void handle_SET_POSITIONING_BOARD_Data(uint8_t  hasBoard)
             {
                 (void)hasBoard;
+            }
+
+            virtual void handle_SET_LEDS_Request(uint8_t  red, uint8_t  green, uint8_t  blue)
+            {
+                (void)red;
+                (void)green;
+                (void)blue;
+            }
+
+            virtual void handle_SET_LEDS_Data(uint8_t  red, uint8_t  green, uint8_t  blue)
+            {
+                (void)red;
+                (void)green;
+                (void)blue;
             }
 
         public:
@@ -2340,6 +2369,23 @@ namespace hf {
                 bytes[6] = CRC8(&bytes[3], 3);
 
                 return 7;
+            }
+
+            static uint8_t serialize_SET_LEDS(uint8_t bytes[], uint8_t  red, uint8_t  green, uint8_t  blue)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 3;
+                bytes[4] = 227;
+
+                memcpy(&bytes[5], &red, sizeof(uint8_t));
+                memcpy(&bytes[6], &green, sizeof(uint8_t));
+                memcpy(&bytes[7], &blue, sizeof(uint8_t));
+
+                bytes[8] = CRC8(&bytes[3], 5);
+
+                return 9;
             }
 
     }; // class MspParser


### PR DESCRIPTION
## Issue/Feature this PR addresses

Enable to set LEDs (Red -PIN 25- ,Green -PIN 26-, Blue -PIN 38-) on/off with an MSP message.

## Current behavior

LEDs cannot be turned on/off via an MSP message

## Expected behavior after merge

LEDs can be turned on/off via an MSP message ( the MSP message ID is 227)