### PR TITLE
Set motor pins according to the Mosquito version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * #48 MSP message and methods to calibrate ESCs
 * #50 Check if position board is connected via MSP
 * #55 Enable setting LEDs on/off with an MSP message
+* #68 Motor pins are set according to the specified Mosquito version
 
 ### Changed
 

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -69,8 +69,6 @@ namespace hf {
 
         protected:
 
-            const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
-
             virtual void writeMotor(uint8_t index, float value) = 0;
 
             virtual bool  getQuaternion(float quat[4]) override 
@@ -155,6 +153,8 @@ namespace hf {
 
         protected:
 
+            const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
+
             virtual void writeMotor(uint8_t index, float value) override
             {
                 analogWrite(MOTOR_PINS[index], (uint16_t)(PWM_MIN+value*(PWM_MAX-PWM_MIN)) >> 3);
@@ -182,6 +182,8 @@ namespace hf {
 
         protected:
 
+            const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
+
             virtual void writeMotor(uint8_t index, float value) override
             {
                 // Serial.println(value,8);
@@ -205,6 +207,8 @@ namespace hf {
     class BonadroneBrushed : public Bonadrone {
 
         protected:
+
+            const uint8_t MOTOR_PINS[4] = {39, 30, 40, 31};
 
             virtual void writeMotor(uint8_t index, float value) override
             {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #57

When initializing the firmware the motor pins should be set automatically according to the specified Mosquito version. 

## Current behavior before PR

Motor pins are set to the pins of the Mosquito 150 independently of the specified Mosquito version.

## Desired behavior after PR is merged

Motor pins are automatically set according to the specified Mosquito version. Motors in both Mosquito versions spin without problems.
