### PR TITLE
Transmitter calibration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * #45 Allow to set rangefinder parameters with an MSP message
 * #55 Enable setting LEDs on/off with an MSP message
 * #68 Motor pins are set according to the specified Mosquito version
+* #70 Transmitter calibration
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -229,6 +229,16 @@
    {"comment": "Specify whether the positioning board is present or not"},
    {"red": "byte"},
    {"green": "byte"},
-   {"blue": "byte"}]
+   {"blue": "byte"}],
+   
+  "RC_CALIBRATION":
+  [{"ID": 214},
+   {"comment": "Calibrate the transmitter"},
+   {"stage": "byte"}],
+
+  "RC_CALIBRATION_STATUS":
+  [{"ID": 119},
+   {"comment": "Return the status of the transmitter calibration"},
+   {"status": "byte"}]
 
 }

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -276,6 +276,7 @@ namespace hf {
                         break;
 
                     case HEADER_CMD:
+                        _state = IDLE;
                         if (_offset < _dataSize) {
                             _checksum ^= c;
                             _inBuf[_offset++] = c;
@@ -288,7 +289,6 @@ namespace hf {
                                     dispatchDataMessage();
                                 }
                             }
-                            _state = IDLE;
                         }
 
                 } // switch (_state)

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -38,7 +38,7 @@ namespace hf {
             static const uint8_t MAXMSG = 255;
             
             // Number of EEPROM reserved slots for parameters
-            static const int PARAMETER_SLOTS = 100;
+            static const int PARAMETER_SLOTS = 150;
 
         private:
 

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -276,11 +276,11 @@ namespace hf {
                         break;
 
                     case HEADER_CMD:
-                        _state = IDLE;
                         if (_offset < _dataSize) {
                             _checksum ^= c;
                             _inBuf[_offset++] = c;
                         } else  {
+                            _state = IDLE;
                             if (_checksum == c) {        // compare calculated and transferred _checksum
                                 if (_direction == 0) {
                                     dispatchRequestMessage();

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -40,3 +40,12 @@ typedef struct {
 
 } state_t;
 
+typedef struct {
+    bool _endStage1 = false;
+    bool _endStage2 = false;
+    uint8_t _rcCalibrationStatus = 0;
+    float _center[3] = {0, 0, 0};   // R, P, Y
+    float _min[4] = {0, 0, 0, 0};   // T, R, P, Y
+    float _max[4] = {0, 0, 0, 0};   // T, R, P, Y
+} tx_calibration_t;
+

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -471,6 +471,7 @@ namespace hf {
                         bool newData = _receiver->getDemands(_state.eulerAngles[AXIS_YAW] - _yawInitial);
                         if (newData)
                         {
+                          // XXX Calibration logic of stage 1
                         }
                         doSerialComms();
                       }
@@ -483,12 +484,14 @@ namespace hf {
                         bool newData = _receiver->getDemands(_state.eulerAngles[AXIS_YAW] - _yawInitial);
                         if (newData)
                         {
+                          // XXX Calibration logic of stage 2
                         }
                         doSerialComms();
                       }
                       break;
                   case 2:
                       _endStage2 = true;
+                      // XXX Calibration logic of stage 3
                       break;
                 }
                 _endStage1 = false;

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -289,6 +289,7 @@ namespace hf {
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
             static const uint8_t CALIBRATE_ESC     = 2;
+            static const uint8_t TX_CALIBRATED     = 3;
 
 
             virtual void handle_SET_ARMED_Request(uint8_t  flag)
@@ -553,6 +554,8 @@ namespace hf {
                 EEPROM.put(TRANSMITER_TRIMS + 10 * sizeof(float), _tx_calibration._max[3]);
                 // Mark calibration as successful
                 _tx_calibration._rcCalibrationStatus = 1;
+                uint8_t config = EEPROM.read(GENERAL_CONFIG);
+                EEPROM.put(GENERAL_CONFIG, config | (1 << TX_CALIBRATED));
                 // // XXX Debug calibration results
                 // Serial.print(_tx_calibration._center[0], 8);
                 // Serial.print(",");

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -474,6 +474,8 @@ namespace hf {
             {
                 switch (stage) {
                   case 0:
+                      _endStage2 = true;
+                      _endStage1 = false;
                       while (!_endStage1)
                       {
                         // Check whether receiver data is available
@@ -487,6 +489,7 @@ namespace hf {
                       break;
                   case 1:
                       _endStage1 = true;
+                      _endStage2 = false;
                       while (!_endStage2)
                       {
                         // Check whether receiver data is available
@@ -499,6 +502,7 @@ namespace hf {
                       }
                       break;
                   case 2:
+                      _endStage1 = true;
                       _endStage2 = true;
                       // XXX Calibration logic of stage 3
                       break;

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -288,6 +288,8 @@ namespace hf {
             static const uint8_t N_PID_CONSTANTS   = 16;
             static const uint8_t RANGE_PARAMS      = PID_CONSTANTS + N_PID_CONSTANTS * sizeof(float);
             static const uint8_t N_RANGE_PARAMS    = 3;
+            static const uint8_t TRANSMITER_TRIMS  = RANGE_PARAMS + N_RANGE_PARAMS * sizeof(float);
+            static const uint8_t N_TRIMS           = 11;
             // booleans values are stored as the bits of the byte at address 0
             static const uint8_t MOSQUITO_VERSION  = 0;
             static const uint8_t POSITIONING_BOARD = 1;
@@ -534,36 +536,47 @@ namespace hf {
                     break;
                   case 2:
                     {
-                      // Calibration logic of stage 3: Store params
+                      // Calibration logic of stage 3: End calibration
                       _endStage1 = true;
                       _endStage2 = true;
                     }
                     break;
                 }
-                Serial.println("Over");
-                // XXX Debug calibration results
-                Serial.print(_center[0], 8);
-                Serial.print(",");
-                Serial.print(_center[1], 8);
-                Serial.print(",");
-                Serial.println(_center[2], 8);
+                // Store trims
+                EEPROM.put(TRANSMITER_TRIMS, _min[0]);
+                EEPROM.put(TRANSMITER_TRIMS + 1 * sizeof(float), _max[0]);
+                EEPROM.put(TRANSMITER_TRIMS + 2 * sizeof(float), _min[1]);
+                EEPROM.put(TRANSMITER_TRIMS + 3 * sizeof(float), _center[0]);
+                EEPROM.put(TRANSMITER_TRIMS + 4 * sizeof(float), _max[1]);
+                EEPROM.put(TRANSMITER_TRIMS + 5 * sizeof(float), _min[2]);
+                EEPROM.put(TRANSMITER_TRIMS + 6 * sizeof(float), _center[1]);
+                EEPROM.put(TRANSMITER_TRIMS + 7 * sizeof(float), _max[2]);
+                EEPROM.put(TRANSMITER_TRIMS + 8 * sizeof(float), _min[3]);
+                EEPROM.put(TRANSMITER_TRIMS + 9 * sizeof(float), _center[2]);
+                EEPROM.put(TRANSMITER_TRIMS + 10 * sizeof(float), _max[3]);
                 
-                Serial.print(_min[0], 8);
-                Serial.print(",");
-                Serial.print(_min[1], 8);
-                Serial.print(",");
-                Serial.print(_min[2], 8);
-                Serial.print(",");
-                Serial.println(_min[3], 8);
-
-                Serial.print(_max[0], 8);
-                Serial.print(",");
-                Serial.print(_max[1], 8);
-                Serial.print(",");
-                Serial.print(_max[2], 8);
-                Serial.print(",");
-                Serial.println(_max[3], 8);
-
+                // // XXX Debug calibration results
+                // Serial.print(_center[0], 8);
+                // Serial.print(",");
+                // Serial.print(_center[1], 8);
+                // Serial.print(",");
+                // Serial.println(_center[2], 8);
+                // 
+                // Serial.print(_min[0], 8);
+                // Serial.print(",");
+                // Serial.print(_min[1], 8);
+                // Serial.print(",");
+                // Serial.print(_min[2], 8);
+                // Serial.print(",");
+                // Serial.println(_min[3], 8);
+                // 
+                // Serial.print(_max[0], 8);
+                // Serial.print(",");
+                // Serial.print(_max[1], 8);
+                // Serial.print(",");
+                // Serial.print(_max[2], 8);
+                // Serial.print(",");
+                // Serial.println(_max[3], 8);
             }
             
             virtual void handle_RC_CALIBRATION_STATUS_Request(uint8_t & status) override

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -53,6 +53,7 @@ namespace hf {
             // transmitter calibration
             bool _endStage1 = false;
             bool _endStage2 = false;
+            uint8_t _rcCalibrationStatus = 0;
             
             // Passed to Hackflight::init() for a particular build
             Board      * _board;
@@ -496,11 +497,8 @@ namespace hf {
             
             virtual void handle_RC_CALIBRATION_STATUS_Request(uint8_t & status) override
             {
-                (void)status;
-                //status = _rcCalibrationStatus;
+                status = _rcCalibrationStatus;
             }
-
-
 
         public:
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -477,7 +477,7 @@ namespace hf {
                       while (!_endStage1)
                       {
                         // Check whether receiver data is available
-                        bool newData = _receiver->getDemands(_state.eulerAngles[AXIS_YAW] - _yawInitial);
+                        bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
                         if (newData)
                         {
                           // XXX Calibration logic of stage 1
@@ -490,7 +490,7 @@ namespace hf {
                       while (!_endStage2)
                       {
                         // Check whether receiver data is available
-                        bool newData = _receiver->getDemands(_state.eulerAngles[AXIS_YAW] - _yawInitial);
+                        bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
                         if (newData)
                         {
                           // XXX Calibration logic of stage 2

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -478,7 +478,6 @@ namespace hf {
                 switch (stage) {
                   case 0:
                     {
-                      Serial.println("Stage 1");
                       // Calibration logic of stage 1: T min and R, P, Y center values
                       _endStage2 = true;
                       _endStage1 = false;
@@ -497,7 +496,6 @@ namespace hf {
                               _center[2] += _receiver->getRawval(3);     // Y
                               i += 1;
                           }
-                          //delay(200);
                           doSerialComms();
                       }
                       _min[0] = _min[0] / i;
@@ -509,7 +507,6 @@ namespace hf {
                     break;
                   case 1:
                     {
-                      Serial.println("Stage 2");
                       // Calibration logic of stage 2: T max and R, P, Y min and max
                       _endStage1 = true;
                       _endStage2 = false;
@@ -532,14 +529,12 @@ namespace hf {
                               }
                             }
                         }
-                        //delay(200);
                         doSerialComms();
                       }
                     }
                     break;
                   case 2:
                     {
-                      Serial.println("Stage 3");
                       // Calibration logic of stage 3: Store params
                       _endStage1 = true;
                       _endStage2 = true;

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -489,7 +489,6 @@ namespace hf {
                           bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
                           if (newData)
                           {
-                              Serial.println(_receiver->getRawval(0));
                               _min[0] += _receiver->getRawval(0);        // T
                               _center[0] += _receiver->getRawval(1);     // R
                               _center[1] += _receiver->getRawval(2);     // P

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -486,8 +486,8 @@ namespace hf {
                       while (!_endStage1)
                       {
                           // Check whether receiver data is available
+                          _receiver->pollForFrame();
                           bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
-                          Serial.println(newData);
                           if (newData)
                           {
                               Serial.println(_receiver->getRawval(0));
@@ -516,6 +516,7 @@ namespace hf {
                       while (!_endStage2)
                       {
                         // Check whether receiver data is available
+                        _receiver->pollForFrame();
                         bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
                         if (newData)
                         {

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -483,7 +483,7 @@ namespace hf {
                       {
                           // Check whether receiver data is available
                           _receiver->pollForFrame();
-                          bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
+                          bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial, true);
                           if (newData)
                           {
                               _tx_calibration._min[0] += _receiver->getRawval(0);        // T
@@ -494,10 +494,12 @@ namespace hf {
                           }
                           doSerialComms();
                       }
+
                       _tx_calibration._min[0] = _tx_calibration._min[0] / i;
+
                       for (int k=0; k<3; k++)
                       {
-                        _tx_calibration._center[k] = _tx_calibration._center[k] / i;
+                          _tx_calibration._center[k] = _tx_calibration._center[k] / i;
                       }
                     }
                     break;
@@ -510,7 +512,7 @@ namespace hf {
                       {
                         // Check whether receiver data is available
                         _receiver->pollForFrame();
-                        bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial);
+                        bool newData = _receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial, true);
                         if (newData)
                         {
                             // Update max of T, R, P, Y and min of R, P, Y
@@ -552,27 +554,27 @@ namespace hf {
                 // Mark calibration as successful
                 _tx_calibration._rcCalibrationStatus = 1;
                 // // XXX Debug calibration results
-                // Serial.print(_center[0], 8);
+                // Serial.print(_tx_calibration._center[0], 8);
                 // Serial.print(",");
-                // Serial.print(_center[1], 8);
+                // Serial.print(_tx_calibration._center[1], 8);
                 // Serial.print(",");
-                // Serial.println(_center[2], 8);
+                // Serial.println(_tx_calibration._center[2], 8);
                 // 
-                // Serial.print(_min[0], 8);
+                // Serial.print(_tx_calibration._min[0], 8);
                 // Serial.print(",");
-                // Serial.print(_min[1], 8);
+                // Serial.print(_tx_calibration._min[1], 8);
                 // Serial.print(",");
-                // Serial.print(_min[2], 8);
+                // Serial.print(_tx_calibration._min[2], 8);
                 // Serial.print(",");
-                // Serial.println(_min[3], 8);
+                // Serial.println(_tx_calibration._min[3], 8);
                 // 
-                // Serial.print(_max[0], 8);
+                // Serial.print(_tx_calibration._max[0], 8);
                 // Serial.print(",");
-                // Serial.print(_max[1], 8);
+                // Serial.print(_tx_calibration._max[1], 8);
                 // Serial.print(",");
-                // Serial.print(_max[2], 8);
+                // Serial.print(_tx_calibration._max[2], 8);
                 // Serial.print(",");
-                // Serial.println(_max[3], 8);
+                // Serial.println(_tx_calibration._max[3], 8);
             }
             
             virtual void handle_RC_CALIBRATION_STATUS_Request(uint8_t & status) override

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -79,6 +79,10 @@ namespace hf {
               float _rx;
               float _ry;
               float _rz;
+              // transmitter trims
+              float _min[4] = {0,0,0,0}; 
+              float _center[3] = {0,0,0}; 
+              float _max[4] = {0,0,0,0}; 
 
               // Required objects to run Hackflight
               hf::Hackflight h;
@@ -110,6 +114,17 @@ namespace hf {
                   EEPROM.get(RANGE_PARAMS, _rx);
                   EEPROM.get(RANGE_PARAMS + 1 * sizeof(float), _ry);
                   EEPROM.get(RANGE_PARAMS + 2 * sizeof(float), _rz);
+                  EEPROM.get(TRANSMITER_TRIMS, _min[0]);
+                  EEPROM.get(TRANSMITER_TRIMS + 1 * sizeof(float), _max[0]);
+                  EEPROM.get(TRANSMITER_TRIMS + 2 * sizeof(float), _min[1]);
+                  EEPROM.get(TRANSMITER_TRIMS + 3 * sizeof(float), _center[0]);
+                  EEPROM.get(TRANSMITER_TRIMS + 4 * sizeof(float), _max[1]);
+                  EEPROM.get(TRANSMITER_TRIMS + 5 * sizeof(float), _min[2]);
+                  EEPROM.get(TRANSMITER_TRIMS + 6 * sizeof(float), _center[1]);
+                  EEPROM.get(TRANSMITER_TRIMS + 7 * sizeof(float), _max[2]);
+                  EEPROM.get(TRANSMITER_TRIMS + 8 * sizeof(float), _min[3]);
+                  EEPROM.get(TRANSMITER_TRIMS + 9 * sizeof(float), _center[2]);
+                  EEPROM.get(TRANSMITER_TRIMS + 10 * sizeof(float), _max[3]);
               }
               
               void calibrateESCsStandard(void)

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -58,6 +58,7 @@ namespace hf {
               bool _hasPositioningBoard = false;
               bool _isMosquito90 = false;
               bool _calibrateESC = false;
+              bool _txCalibrated = false;
               // Connection status (false unless proven otherwise)
               bool _positionBoardConnected = false;
               // Rate PID params
@@ -98,6 +99,7 @@ namespace hf {
                   _isMosquito90 = (config >> MOSQUITO_VERSION) & 1;
                   _hasPositioningBoard = (config >> POSITIONING_BOARD) & 1;
                   _calibrateESC = (config >> CALIBRATE_ESC) & 1;
+                  _txCalibrated = (config >> TX_CALIBRATED) & 1;
                   // Load Rate PID parameters (each float is 4 bytes)
                   EEPROM.get(PID_CONSTANTS, _gyroRollPitchP);
                   EEPROM.get(PID_CONSTANTS + 1 * sizeof(float), _gyroRollPitchI);
@@ -257,7 +259,8 @@ namespace hf {
                 loadParameters();
                 // begin the serial port for the ESP32
                 Serial4.begin(115200);
-
+                
+                rc.setCalibrationStatus(_txCalibrated);
                 // Trim receiver via software
                 trimReceiver();
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -236,11 +236,11 @@ namespace hf {
                   {
                     float m_pos = 1.0 / (_max[k+1] - _center[k]); 
                     float n_pos =  - (m_pos * _center[k]);
-                    float m_neg = 1.0 / (_center[k] - _min[k+1]); 
+                    float m_neg = - 1.0 / (_min[k+1] - _center[k]); 
                     float n_neg =  - (m_neg * _center[k]);
                     rc.setTrim(m_pos, n_pos, m_neg, n_neg, k+1);
                   }
-                  // Set T trims
+                  // Set Throttle trims
                   float m = 2.0 / (_max[0] - _min[0]);
                   float n = 1.0 - m*_max[0];
                   rc.setTrim(m, n, m, n, 0);

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -229,6 +229,23 @@ namespace hf {
                   digitalWrite(LED_G, HIGH);
               }
 
+              void trimReceiver(void)
+              {
+                  // Set trims for R, P, Y
+                  for (int k=0; k<3; k++)
+                  {
+                    float m_pos = 1.0 / (_max[k+1] - _center[k]); 
+                    float n_pos =  - (m_pos * _center[k]);
+                    float m_neg = 1.0 / (_center[k] - _min[k+1]); 
+                    float n_neg =  - (m_neg * _center[k]);
+                    rc.setTrim(m_pos, n_pos, m_neg, n_neg, k+1);
+                  }
+                  // Set T trims
+                  float m = 2.0 / (_max[0] - _min[0]);
+                  float n = 1.0 - m*_max[0];
+                  rc.setTrim(m, n, m, n, 0);
+              }
+
         protected:
 
 
@@ -242,9 +259,7 @@ namespace hf {
                 Serial4.begin(115200);
 
                 // Trim receiver via software
-                rc.setTrimRoll(-0.0030506f);
-                rc.setTrimPitch(-0.0372178f);
-                rc.setTrimYaw(-0.0384381f);
+                trimReceiver();
 
                 // Instantiate controllers after loading parameters
                 hf::Rate * ratePid = new hf::Rate(

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -276,6 +276,7 @@ namespace hf {
                         break;
 
                     case HEADER_CMD:
+                        _state = IDLE;
                         if (_offset < _dataSize) {
                             _checksum ^= c;
                             _inBuf[_offset++] = c;
@@ -288,7 +289,6 @@ namespace hf {
                                     dispatchDataMessage();
                                 }
                             }
-                            _state = IDLE;
                         }
 
                 } // switch (_state)

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -767,6 +767,24 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 214:
+                    {
+                        uint8_t stage = 0;
+                        memcpy(&stage,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_RC_CALIBRATION_Request(stage);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 119:
+                    {
+                        uint8_t status = 0;
+                        handle_RC_CALIBRATION_STATUS_Request(status);
+                        prepareToSendBytes(1);
+                        sendByte(status);
+                        serialize8(_checksum);
+                        } break;
+
                 }
             }
 
@@ -972,6 +990,12 @@ namespace hf {
                     {
                         uint8_t version = getArgument(0);
                         handle_FIRMWARE_VERSION_Data(version);
+                        } break;
+
+                    case 119:
+                    {
+                        uint8_t status = getArgument(0);
+                        handle_RC_CALIBRATION_STATUS_Data(status);
                         } break;
 
                 }
@@ -1451,6 +1475,26 @@ namespace hf {
                 (void)red;
                 (void)green;
                 (void)blue;
+            }
+
+            virtual void handle_RC_CALIBRATION_Request(uint8_t  stage)
+            {
+                (void)stage;
+            }
+
+            virtual void handle_RC_CALIBRATION_Data(uint8_t  stage)
+            {
+                (void)stage;
+            }
+
+            virtual void handle_RC_CALIBRATION_STATUS_Request(uint8_t & status)
+            {
+                (void)status;
+            }
+
+            virtual void handle_RC_CALIBRATION_STATUS_Data(uint8_t & status)
+            {
+                (void)status;
             }
 
         public:
@@ -2386,6 +2430,48 @@ namespace hf {
                 bytes[8] = CRC8(&bytes[3], 5);
 
                 return 9;
+            }
+
+            static uint8_t serialize_RC_CALIBRATION(uint8_t bytes[], uint8_t  stage)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 214;
+
+                memcpy(&bytes[5], &stage, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_RC_CALIBRATION_STATUS_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 119;
+                bytes[5] = 119;
+
+                return 6;
+            }
+
+            static uint8_t serialize_RC_CALIBRATION_STATUS(uint8_t bytes[], uint8_t  status)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 119;
+
+                memcpy(&bytes[5], &status, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
             }
 
     }; // class MspParser

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -38,7 +38,7 @@ namespace hf {
             static const uint8_t MAXMSG = 255;
             
             // Number of EEPROM reserved slots for parameters
-            static const int PARAMETER_SLOTS = 100;
+            static const int PARAMETER_SLOTS = 150;
 
         private:
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -276,11 +276,11 @@ namespace hf {
                         break;
 
                     case HEADER_CMD:
-                        _state = IDLE;
                         if (_offset < _dataSize) {
                             _checksum ^= c;
                             _inBuf[_offset++] = c;
                         } else  {
+                            _state = IDLE;
                             if (_checksum == c) {        // compare calculated and transferred _checksum
                                 if (_direction == 0) {
                                     dispatchRequestMessage();

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -75,8 +75,10 @@ namespace hf {
             return rcFun(command, CYCLIC_EXPO, CYCLIC_RATE);
         }
 
-        void applyTrims(void)
+        void applyTrims(bool calibrating)
         {
+            if (calibrating) return;
+ 
             for (int channel=0; channel<4; channel++)
             {
                 float val = rawvals[_channelMap[channel]];
@@ -190,7 +192,7 @@ namespace hf {
         {
         }
 
-        bool getDemands(float yawAngle)
+        bool getDemands(float yawAngle, bool calibrating = false)
         {
             // Wait till there's a new frame
             if (!gotNewFrame() && !_gotNewFrame) return false;
@@ -198,7 +200,7 @@ namespace hf {
             // Read raw channel values
             readRawvals(_bypassReceiver);
             
-            applyTrims();
+            applyTrims(calibrating);
 
             // Convert raw [-1,+1] to absolute value
             demands.roll  = makePositiveCommand(CHANNEL_ROLL);

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -75,6 +75,20 @@ namespace hf {
             return rcFun(command, CYCLIC_EXPO, CYCLIC_RATE);
         }
 
+        void applyTrims(void)
+        {
+            for (int channel=0; channel<4; channel++)
+            {
+                float val = rawvals[_channelMap[channel]];
+                if (val < 0)
+                {
+                    rawvals[_channelMap[channel]] = M_NEG[channel] * val + N_NEG[channel];
+                } else {
+                    rawvals[_channelMap[channel]] = M_POS[channel] * val + N_POS[channel];                  
+                }
+            }
+        }
+
         float makePositiveCommand(uint8_t channel)
         {
             return fabs(rawvals[_channelMap[channel]]);
@@ -183,6 +197,8 @@ namespace hf {
 
             // Read raw channel values
             readRawvals(_bypassReceiver);
+            
+            applyTrims();
 
             // Convert raw [-1,+1] to absolute value
             demands.roll  = makePositiveCommand(CHANNEL_ROLL);

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -256,6 +256,8 @@ namespace hf {
             _trimYaw = trim;
         }
         
+        virtual void pollForFrame(void) {}
+        
         // Setters and getters of the attributes required to be able to use the
         // ESP32 and MSP messages as a receiver. For now, we offer this possibility
         // to work with any receiver by implementing this methods in the receiver

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -53,6 +53,7 @@ namespace hf {
         const float THROTTLE_MID      = 0.00f;
         const float THROTTLE_EXPO     = 0.20f;
         
+        bool _calibrated = false;
         // Arrays to trim demands 
         float M_POS[4];
         float N_POS[4];
@@ -77,7 +78,7 @@ namespace hf {
 
         void applyTrims(bool calibrating)
         {
-            if (calibrating) return;
+            if (calibrating || !_calibrated) return;
  
             for (int channel=0; channel<4; channel++)
             {
@@ -286,6 +287,11 @@ namespace hf {
             N_POS[channel] = n_pos;
             M_NEG[channel] = m_neg;
             N_NEG[channel] = n_neg;
+        }
+        
+        void setCalibrationStatus(bool calibrated)
+        {
+            _calibrated = calibrated;
         }
         
         virtual void pollForFrame(void) {}

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -52,6 +52,12 @@ namespace hf {
         const float CYCLIC_RATE       = 0.90f;
         const float THROTTLE_MID      = 0.00f;
         const float THROTTLE_EXPO     = 0.20f;
+        
+        // Arrays to trim demands 
+        float M_POS[4];
+        float N_POS[4];
+        float M_NEG[4];
+        float N_NEG[4];
 
         float adjustCommand(float command, uint8_t channel)
         {
@@ -254,6 +260,14 @@ namespace hf {
         void setTrimYaw(float trim)
         {
             _trimYaw = trim;
+        }
+        
+        void setTrim(float m_pos, float n_pos, float m_neg, float n_neg, int channel)
+        {
+            M_POS[channel] = m_pos;
+            N_POS[channel] = n_pos;
+            M_NEG[channel] = m_neg;
+            N_NEG[channel] = n_neg;
         }
         
         virtual void pollForFrame(void) {}

--- a/src/receivers/sbus.hpp
+++ b/src/receivers/sbus.hpp
@@ -77,7 +77,6 @@ namespace hf {
             bool gotNewFrame(void)
             {
                 if (rx.gotNewFrame()) {
-                  Serial.println("Got frame");
                     uint8_t failsafe = 0;
                     uint16_t lostFrames = 0;
 

--- a/src/receivers/sbus.hpp
+++ b/src/receivers/sbus.hpp
@@ -77,7 +77,7 @@ namespace hf {
             bool gotNewFrame(void)
             {
                 if (rx.gotNewFrame()) {
-
+                  Serial.println("Got frame");
                     uint8_t failsafe = 0;
                     uint16_t lostFrames = 0;
 
@@ -106,6 +106,13 @@ namespace hf {
             bool lostSignal(void)
             {
                 return _failsafeCount > MAX_FAILSAFE;
+            }
+
+            virtual void pollForFrame(void) override
+            {
+                serialEvent1();
+                serialEvent2();
+                serialEvent3();
             }
 
         public:


### PR DESCRIPTION
**Note**: I think this is possibly one of the most complex pieces of software I have ever developed. This might be due to either the problem being actually complex or me lacking programming experience (or a bit of both).

### TO DO List

- [x] After TX calibration, set the successful/error flag depending on the calibration result.
- [x] Compute mappings and apply them when getting new demands.
- [x] If the transmitter has not been calibrated bypass the  mapping

Linked issue: #56 

The implementation of the transmitter calibration has been developed with the following idea in mind: **That it has to be self-contained**. Why? These are the main reasons that come off the top of my head:
1. It seems reasonable to, if possible, perform all the actions that are related with a particular MSP message inside its respective handler. Even more when the action to perform does not affect the global behavior of the drone and is just an additional feature.
3. Furthermore, MSP message handling is currently done inside the [`Hackflight`](https://github.com/BonaDrone/Hackflight/blob/06fe35f618ebedb435cff61db9bef9515d851366/src/hackflight.hpp#L43) class, which is the main class of the firmware that includes the core functionalities that allow the Mosquitos to fly. Keeping this class simple is a must to avoid bugs and make it easy to understand and follow. This means that any unnecessary variables and methods should be avoided at all costs. Ideally handlers will be moved away from the `Hackflight` class, but this is not the case yet.
4. Since it is a specific feature that will be only used from time to time, having helper methods and variables hanging around only adds noise and makes code harder to understand.

**Principle of operation** (It is a good idea to read the code with the following diagram at hand)

![tx_calibration](https://user-images.githubusercontent.com/9968427/53747739-379b6400-3ea4-11e9-93f7-7467c6d23002.png)


were the calibration stage is controlled by a `switch` construction, looping and processing new frames is achieved with a `while` and switching between calibration stages via recursive calls to `handle_RC_CALIBRATION_Request`.

**Please read this carefully to fully understand the code**:
There are some subtleties in the modifications contained in this PR that deserve an explanation. Each of them has its own reasons to exist, reasons that are explained below.    
1. **Including a new method that enables polling for new transmitter frames**:
[New transmitter frames](https://github.com/BonaDrone/Hackflight/blob/06fe35f618ebedb435cff61db9bef9515d851366/src/receivers/sbus.hpp#L30) are obtained via the `SerialEvent` call that occurs whenever new data comes in the hardware serial RX. This routine is run between each time `loop()` runs, so if the program gets stuck in a `while` indefinitely, new TX frames will never be obtained. This is why we need a way to poll the hardware serial to see if new data is available.
See [1](https://www.arduino.cc/en/Reference/SerialEvent) and [2](https://www.arduino.cc/en/Tutorial/SerialEvent) for further reference.

2. **Moving the assignation** `_state = IDLE` **in** `mspparser.hpp` **before the checksum validation**: 
We are recursively calling the [`dispatchRequestMessage`](https://github.com/BonaDrone/Hackflight/blob/06fe35f618ebedb435cff61db9bef9515d851366/src/mspparser.hpp#L285) in [`mspparser.hpp`](https://github.com/BonaDrone/Hackflight/blob/master/src/mspparser.hpp), which means that the call to the [`parse`](https://github.com/BonaDrone/Hackflight/blob/06fe35f618ebedb435cff61db9bef9515d851366/src/mspparser.hpp#L229) method does not return until the calibration process ends. If the assignation of the parser state to `IDLE` is done after the call to `dispatchRequestMessage`, once we enter the TX calibration process the parser status will be left at `HEADER_CMD`. This means that the next MSP message will not be processed properly - since the parser state is not properly set- and hence we might lose relevant data. To solve this and enable recursive calls in MSP message handlers, the parser state should be set to `IDLE` before dispatching the request.

## Description of the issue/feature this PR addresses

Linked issue: #56 

Include in the firmware a new process/feature/task that allows to calibrate transmitter values when requested by the platform (via MSP). The goal is to properly map the specific MAX / CENTER / MIN values of each of the sticks of a particular transmitter to the range of values the firmware expects (-1 for MIN, 0 for CENTER and 1 for MAX).

## Current behavior before PR

Transmitter calibration cannot be performed because the feature is not implemented.

## Desired behavior after PR is merged

The firmware includes a new functionality that can be triggered from the platform via MSP and that enables transmitter calibration. Once the transmitter has been calibrated, stick inputs are mapped to the correct and expected range.
