### PR TITLE
Battery Monitoring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * #50 Check if position board is connected via MSP
 * #55 Enable setting LEDs on/off with an MSP message
 * #68 Motor pins are set according to the specified Mosquito version
+* #73 Battery monitoring and low battery trigger 
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -229,6 +229,16 @@
    {"comment": "Specify whether the positioning board is present or not"},
    {"red": "byte"},
    {"green": "byte"},
-   {"blue": "byte"}]
+   {"blue": "byte"}],
+   
+   "SET_BATTERY_VOLTAGE":
+   [{"ID": 228},
+    {"comment": "Set the current voltage in the STM32 controller, measured in the ESP32"},
+    {"batteryVoltage": "float"}],
+    
+    "GET_BATTERY_VOLTAGE":
+    [{"ID": 125},
+     {"comment": "Get the current battery voltage"},
+     {"voltage": "float"}]
 
 }

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -152,7 +152,7 @@ namespace hf {
             const uint16_t PWM_MAX = 2000;
 
         protected:
-
+            
             const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
 
             virtual void writeMotor(uint8_t index, float value) override
@@ -161,7 +161,7 @@ namespace hf {
             }
 
         public:
-
+            
             BonadroneStandard(void) : Bonadrone()
             {
                 for (uint8_t k=0; k<4; ++k) {
@@ -181,7 +181,7 @@ namespace hf {
             const uint16_t PWM_MAX = 500;
 
         protected:
-
+            
             const uint8_t MOTOR_PINS[4] = {3, 4, 5, 6};
 
             virtual void writeMotor(uint8_t index, float value) override
@@ -192,7 +192,7 @@ namespace hf {
             }
 
         public:
-
+          
             BonadroneMultiShot(void) : Bonadrone()
             {
                 for (uint8_t k=0; k<4; ++k) {
@@ -217,7 +217,7 @@ namespace hf {
 
 
         public:
-
+            
             BonadroneBrushed(void) : Bonadrone()
         {
             for (int k=0; k<4; ++k) {

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -44,7 +44,7 @@ typedef struct {
     float positionY;
     float velocityForward;  
     float velocityRightward;
-    float voltage; 
+    float batteryVoltage; 
 
 } state_t;
 

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -43,7 +43,8 @@ typedef struct {
     float positionX;
     float positionY;
     float velocityForward;  
-    float velocityRightward; 
+    float velocityRightward;
+    float voltage; 
 
 } state_t;
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -81,7 +81,7 @@ namespace hf {
             bool _lowBattery;
             
             // XXX Store it as an MSP parameter
-            const float _BAT_MIN = 5; // Minimum voltage for 1S Battery
+            const float _BAT_MIN = 3.3; // Minimum voltage for 1S Battery
 
             // Support for headless mode
             float _yawInitial;
@@ -105,13 +105,13 @@ namespace hf {
               if (_board->getTime() - lastTime > 0.5)
               {
                 // Look is the battery is belowe the limit
-                if (_state.batteryVoltage < _BAT_MIN)
+                if (_state.batteryVoltage < _BAT_MIN && _state.batteryVoltage > 2.5)
                 {
                   // Save the first time it detects low battery
                   lastTimeLowBattery = ((isLastLowBattery) ? lastTimeLowBattery:_board->getTime());
                   
                   // Low battery if there has been low battery for more than 5s
-                  // XXX it might be necessary to trigger the low battery action from hereº
+                  // XXX it might be necessary to trigger the low battery action from here
                   _lowBattery = (_board->getTime() - lastTimeLowBattery > 5);
                   
                   // ---- Provisional
@@ -128,9 +128,10 @@ namespace hf {
                 {
                   isLastLowBattery = false;
                 }
+                lastTime = _board->getTime();
               }
                             
-              lastTime = _board->getTime();
+              
             }
             
             void checkQuaternion(void)

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -78,6 +78,10 @@ namespace hf {
             // Safety
             bool _safeToArm;
             bool _failsafe;
+            bool _lowBattery;
+            
+            // XXX Store it as an MSP parameter
+            const float _BAT_MIN = 5; // Minimum voltage for 1S Battery
 
             // Support for headless mode
             float _yawInitial;
@@ -86,7 +90,49 @@ namespace hf {
             {
                 return fabs(_state.eulerAngles[axis]) < _ratePid->maxArmingAngle;
             }
-
+            
+            void checkBattery()
+            {
+              // Frequency management
+              static float lastTime = 0.0;
+              
+              // Battery management
+              static float lastTimeLowBattery = 0.0;
+              static float lastBatteryVoltage = 0.0;
+              static bool  isLastLowBattery = false;
+              
+              // Check battery with a freq. of 2Hz
+              if (_board->getTime() - lastTime > 0.5)
+              {
+                // Look is the battery is belowe the limit
+                if (_state.batteryVoltage < _BAT_MIN)
+                {
+                  // Save the first time it detects low battery
+                  lastTimeLowBattery = ((isLastLowBattery) ? lastTimeLowBattery:_board->getTime());
+                  
+                  // Low battery if there has been low battery for more than 5s
+                  // XXX it might be necessary to trigger the low battery action from hereº
+                  _lowBattery = (_board->getTime() - lastTimeLowBattery > 5);
+                  
+                  // ---- Provisional
+                  if (_lowBattery)
+                  {
+                    pinMode(25, OUTPUT);
+                    digitalWrite(25, LOW);
+                  }
+                  // ---- Provisional
+                  
+                  isLastLowBattery = true;
+                }
+                else
+                {
+                  isLastLowBattery = false;
+                }
+              }
+                            
+              lastTime = _board->getTime();
+            }
+            
             void checkQuaternion(void)
             {
                 // Some quaternion filters may need to know the current time
@@ -436,12 +482,12 @@ namespace hf {
             
             virtual void handle_SET_BATTERY_VOLTAGE_Request(float  batteryVoltage) override
             {
-              _state.voltage = batteryVoltage;
+              _state.batteryVoltage = batteryVoltage;
             }
             
             virtual void handle_GET_BATTERY_VOLTAGE_Request(float & batteryVoltage) override
             {
-                batteryVoltage = _state.voltage;
+                batteryVoltage = _state.batteryVoltage;
             }
             
             virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4) override
@@ -514,6 +560,7 @@ namespace hf {
 
                 // Setup failsafe
                 _failsafe = false;
+                _lowBattery = false;
 
             } // init
 
@@ -545,6 +592,9 @@ namespace hf {
 
             void update(void)
             {
+                // Check Battery
+                checkBattery();
+                
                 // Check planner
                 checkPlanner();
                 // Grab control signal if available

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -104,7 +104,7 @@ namespace hf {
               // Check battery with a freq. of 2Hz
               if (_board->getTime() - lastTime > 0.5)
               {
-                // Look is the battery is belowe the limit
+                // Look if the battery is below the limit
                 if (_state.batteryVoltage < _BAT_MIN && _state.batteryVoltage > 2.5)
                 {
                   // Save the first time it detects low battery

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -434,6 +434,16 @@ namespace hf {
                 
             }
             
+            virtual void handle_SET_BATTERY_VOLTAGE_Request(float  batteryVoltage) override
+            {
+              _state.voltage = batteryVoltage;
+            }
+            
+            virtual void handle_GET_BATTERY_VOLTAGE_Request(float & batteryVoltage) override
+            {
+                batteryVoltage = _state.voltage;
+            }
+            
             virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4) override
             {
                   m1 = _mixer->motorsDisarmed[0];

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -303,6 +303,33 @@ namespace hf {
                 processMissionCommand(_command);
                 switch (_command) {
 
+                    case 3:
+                    {
+                        uint8_t code = 0;
+                        handle_WP_LAND_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 27:
+                    {
+                        uint8_t positionBoardConnected = 0;
+                        handle_POSITION_BOARD_CONNECTED_Request(positionBoardConnected);
+                        prepareToSendBytes(1);
+                        sendByte(positionBoardConnected);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 226:
+                    {
+                        uint8_t flag = 0;
+                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_LOST_SIGNAL_Request(flag);
+                        acknowledgeResponse();
+                        } break;
+
                     case 102:
                     {
                         int16_t accx = 0;
@@ -326,367 +353,6 @@ namespace hf {
                         sendShort(magy);
                         sendShort(magz);
                         serialize8(_checksum);
-                        } break;
-
-                    case 121:
-                    {
-                        float c1 = 0;
-                        float c2 = 0;
-                        float c3 = 0;
-                        float c4 = 0;
-                        float c5 = 0;
-                        float c6 = 0;
-                        handle_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
-                        prepareToSendFloats(6);
-                        sendFloat(c1);
-                        sendFloat(c2);
-                        sendFloat(c3);
-                        sendFloat(c4);
-                        sendFloat(c5);
-                        sendFloat(c6);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 222:
-                    {
-                        float c1 = 0;
-                        memcpy(&c1,  &_inBuf[0], sizeof(float));
-
-                        float c2 = 0;
-                        memcpy(&c2,  &_inBuf[4], sizeof(float));
-
-                        float c3 = 0;
-                        memcpy(&c3,  &_inBuf[8], sizeof(float));
-
-                        float c4 = 0;
-                        memcpy(&c4,  &_inBuf[12], sizeof(float));
-
-                        float c5 = 0;
-                        memcpy(&c5,  &_inBuf[16], sizeof(float));
-
-                        float c6 = 0;
-                        memcpy(&c6,  &_inBuf[20], sizeof(float));
-
-                        handle_SET_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 226:
-                    {
-                        uint8_t flag = 0;
-                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_LOST_SIGNAL_Request(flag);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 122:
-                    {
-                        float roll = 0;
-                        float pitch = 0;
-                        float yaw = 0;
-                        handle_ATTITUDE_RADIANS_Request(roll, pitch, yaw);
-                        prepareToSendFloats(3);
-                        sendFloat(roll);
-                        sendFloat(pitch);
-                        sendFloat(yaw);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 123:
-                    {
-                        float estalt = 0;
-                        float vario = 0;
-                        handle_ALTITUDE_METERS_Request(estalt, vario);
-                        prepareToSendFloats(2);
-                        sendFloat(estalt);
-                        sendFloat(vario);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 126:
-                    {
-                        float agl = 0;
-                        float flowx = 0;
-                        float flowy = 0;
-                        handle_LOITER_Request(agl, flowx, flowy);
-                        prepareToSendFloats(3);
-                        sendFloat(agl);
-                        sendFloat(flowx);
-                        sendFloat(flowy);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 216:
-                    {
-                        uint8_t flag = 0;
-                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_SET_ARMED_Request(flag);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 199:
-                    {
-                        int32_t value1 = 0;
-                        int32_t value2 = 0;
-                        handle_FAKE_INT_Request(value1, value2);
-                        prepareToSendInts(2);
-                        sendInt(value1);
-                        sendInt(value2);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 215:
-                    {
-                        float m1 = 0;
-                        memcpy(&m1,  &_inBuf[0], sizeof(float));
-
-                        float m2 = 0;
-                        memcpy(&m2,  &_inBuf[4], sizeof(float));
-
-                        float m3 = 0;
-                        memcpy(&m3,  &_inBuf[8], sizeof(float));
-
-                        float m4 = 0;
-                        memcpy(&m4,  &_inBuf[12], sizeof(float));
-
-                        handle_SET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
-                        acknowledgeResponse();
-                        } break;
-
-                    case 124:
-                    {
-                        float m1 = 0;
-                        float m2 = 0;
-                        float m3 = 0;
-                        float m4 = 0;
-                        handle_GET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
-                        prepareToSendFloats(4);
-                        sendFloat(m1);
-                        sendFloat(m2);
-                        sendFloat(m3);
-                        sendFloat(m4);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 0:
-                    {
-                        uint8_t code = 0;
-                        handle_CLEAR_EEPROM_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 1:
-                    {
-                        uint8_t code = 0;
-                        handle_WP_ARM_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 2:
-                    {
-                        uint8_t code = 0;
-                        handle_WP_DISARM_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 3:
-                    {
-                        uint8_t code = 0;
-                        handle_WP_LAND_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 4:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_TAKE_OFF_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 5:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_FORWARD_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 6:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_BACKWARD_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 7:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_LEFT_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 8:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_GO_RIGHT_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 9:
-                    {
-                        uint8_t meters = 0;
-                        uint8_t code = 0;
-                        handle_WP_CHANGE_ALTITUDE_Request(meters, code);
-                        prepareToSendBytes(2);
-                        sendByte(meters);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 10:
-                    {
-                        uint8_t speed = 0;
-                        uint8_t code = 0;
-                        handle_WP_CHANGE_SPEED_Request(speed, code);
-                        prepareToSendBytes(2);
-                        sendByte(speed);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 11:
-                    {
-                        uint8_t seconds = 0;
-                        uint8_t code = 0;
-                        handle_WP_HOVER_Request(seconds, code);
-                        prepareToSendBytes(2);
-                        sendByte(seconds);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 12:
-                    {
-                        uint8_t degrees = 0;
-                        uint8_t code = 0;
-                        handle_WP_TURN_CW_Request(degrees, code);
-                        prepareToSendBytes(2);
-                        sendByte(degrees);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 13:
-                    {
-                        uint8_t degrees = 0;
-                        uint8_t code = 0;
-                        handle_WP_TURN_CCW_Request(degrees, code);
-                        prepareToSendBytes(2);
-                        sendByte(degrees);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 23:
-                    {
-                        incomingMission = incomingMission ? false : true;
-                        uint8_t flag = 0;
-                        handle_WP_MISSION_FLAG_Request(flag);
-                        prepareToSendBytes(1);
-                        sendByte(flag);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 24:
-                    {
-                        uint8_t protocol = 0;
-                        handle_ESC_CALIBRATION_Request(protocol);
-                        prepareToSendBytes(1);
-                        sendByte(protocol);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 25:
-                    {
-                        uint8_t mosquitoVersion = 0;
-                        handle_MOSQUITO_VERSION_Request(mosquitoVersion);
-                        prepareToSendBytes(1);
-                        sendByte(mosquitoVersion);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 26:
-                    {
-                        uint8_t hasPositionBoard = 0;
-                        handle_POSITION_BOARD_Request(hasPositionBoard);
-                        prepareToSendBytes(1);
-                        sendByte(hasPositionBoard);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 27:
-                    {
-                        uint8_t positionBoardConnected = 0;
-                        handle_POSITION_BOARD_CONNECTED_Request(positionBoardConnected);
-                        prepareToSendBytes(1);
-                        sendByte(positionBoardConnected);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 30:
-                    {
-                        uint8_t flag = 0;
-                        handle_WP_MISSION_BEGIN_Request(flag);
-                        prepareToSendBytes(1);
-                        sendByte(flag);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 50:
-                    {
-                        uint8_t version = 0;
-                        handle_FIRMWARE_VERSION_Request(version);
-                        prepareToSendBytes(1);
-                        sendByte(version);
-                        serialize8(_checksum);
-                        } break;
-
-                    case 223:
-                    {
-                        uint8_t version = 0;
-                        memcpy(&version,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_SET_MOSQUITO_VERSION_Request(version);
-                        acknowledgeResponse();
                         } break;
 
                     case 224:
@@ -743,13 +409,15 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
-                    case 225:
+                    case 199:
                     {
-                        uint8_t hasBoard = 0;
-                        memcpy(&hasBoard,  &_inBuf[0], sizeof(uint8_t));
-
-                        handle_SET_POSITIONING_BOARD_Request(hasBoard);
-                        acknowledgeResponse();
+                        int32_t value1 = 0;
+                        int32_t value2 = 0;
+                        handle_FAKE_INT_Request(value1, value2);
+                        prepareToSendInts(2);
+                        sendInt(value1);
+                        sendInt(value2);
+                        serialize8(_checksum);
                         } break;
 
                     case 227:
@@ -767,12 +435,374 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 122:
+                    {
+                        float roll = 0;
+                        float pitch = 0;
+                        float yaw = 0;
+                        handle_ATTITUDE_RADIANS_Request(roll, pitch, yaw);
+                        prepareToSendFloats(3);
+                        sendFloat(roll);
+                        sendFloat(pitch);
+                        sendFloat(yaw);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 23:
+                    {
+                        incomingMission = incomingMission ? false : true;
+                        uint8_t flag = 0;
+                        handle_WP_MISSION_FLAG_Request(flag);
+                        prepareToSendBytes(1);
+                        sendByte(flag);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 5:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_FORWARD_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 223:
+                    {
+                        uint8_t version = 0;
+                        memcpy(&version,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_MOSQUITO_VERSION_Request(version);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 216:
+                    {
+                        uint8_t flag = 0;
+                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_ARMED_Request(flag);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 30:
+                    {
+                        uint8_t flag = 0;
+                        handle_WP_MISSION_BEGIN_Request(flag);
+                        prepareToSendBytes(1);
+                        sendByte(flag);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 0:
+                    {
+                        uint8_t code = 0;
+                        handle_CLEAR_EEPROM_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 8:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_RIGHT_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 2:
+                    {
+                        uint8_t code = 0;
+                        handle_WP_DISARM_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 7:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_LEFT_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 126:
+                    {
+                        float agl = 0;
+                        float flowx = 0;
+                        float flowy = 0;
+                        handle_LOITER_Request(agl, flowx, flowy);
+                        prepareToSendFloats(3);
+                        sendFloat(agl);
+                        sendFloat(flowx);
+                        sendFloat(flowy);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 1:
+                    {
+                        uint8_t code = 0;
+                        handle_WP_ARM_Request(code);
+                        prepareToSendBytes(1);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 124:
+                    {
+                        float m1 = 0;
+                        float m2 = 0;
+                        float m3 = 0;
+                        float m4 = 0;
+                        handle_GET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
+                        prepareToSendFloats(4);
+                        sendFloat(m1);
+                        sendFloat(m2);
+                        sendFloat(m3);
+                        sendFloat(m4);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 24:
+                    {
+                        uint8_t protocol = 0;
+                        handle_ESC_CALIBRATION_Request(protocol);
+                        prepareToSendBytes(1);
+                        sendByte(protocol);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 12:
+                    {
+                        uint8_t degrees = 0;
+                        uint8_t code = 0;
+                        handle_WP_TURN_CW_Request(degrees, code);
+                        prepareToSendBytes(2);
+                        sendByte(degrees);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 123:
+                    {
+                        float estalt = 0;
+                        float vario = 0;
+                        handle_ALTITUDE_METERS_Request(estalt, vario);
+                        prepareToSendFloats(2);
+                        sendFloat(estalt);
+                        sendFloat(vario);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 6:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_GO_BACKWARD_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 121:
+                    {
+                        float c1 = 0;
+                        float c2 = 0;
+                        float c3 = 0;
+                        float c4 = 0;
+                        float c5 = 0;
+                        float c6 = 0;
+                        handle_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
+                        prepareToSendFloats(6);
+                        sendFloat(c1);
+                        sendFloat(c2);
+                        sendFloat(c3);
+                        sendFloat(c4);
+                        sendFloat(c5);
+                        sendFloat(c6);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 4:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_TAKE_OFF_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 10:
+                    {
+                        uint8_t speed = 0;
+                        uint8_t code = 0;
+                        handle_WP_CHANGE_SPEED_Request(speed, code);
+                        prepareToSendBytes(2);
+                        sendByte(speed);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 125:
+                    {
+                        float voltage = 0;
+                        handle_GET_BATTERY_VOLTAGE_Request(voltage);
+                        prepareToSendFloats(1);
+                        sendFloat(voltage);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 11:
+                    {
+                        uint8_t seconds = 0;
+                        uint8_t code = 0;
+                        handle_WP_HOVER_Request(seconds, code);
+                        prepareToSendBytes(2);
+                        sendByte(seconds);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 215:
+                    {
+                        float m1 = 0;
+                        memcpy(&m1,  &_inBuf[0], sizeof(float));
+
+                        float m2 = 0;
+                        memcpy(&m2,  &_inBuf[4], sizeof(float));
+
+                        float m3 = 0;
+                        memcpy(&m3,  &_inBuf[8], sizeof(float));
+
+                        float m4 = 0;
+                        memcpy(&m4,  &_inBuf[12], sizeof(float));
+
+                        handle_SET_MOTOR_NORMAL_Request(m1, m2, m3, m4);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 225:
+                    {
+                        uint8_t hasBoard = 0;
+                        memcpy(&hasBoard,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_POSITIONING_BOARD_Request(hasBoard);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 13:
+                    {
+                        uint8_t degrees = 0;
+                        uint8_t code = 0;
+                        handle_WP_TURN_CCW_Request(degrees, code);
+                        prepareToSendBytes(2);
+                        sendByte(degrees);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 50:
+                    {
+                        uint8_t version = 0;
+                        handle_FIRMWARE_VERSION_Request(version);
+                        prepareToSendBytes(1);
+                        sendByte(version);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 25:
+                    {
+                        uint8_t mosquitoVersion = 0;
+                        handle_MOSQUITO_VERSION_Request(mosquitoVersion);
+                        prepareToSendBytes(1);
+                        sendByte(mosquitoVersion);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 222:
+                    {
+                        float c1 = 0;
+                        memcpy(&c1,  &_inBuf[0], sizeof(float));
+
+                        float c2 = 0;
+                        memcpy(&c2,  &_inBuf[4], sizeof(float));
+
+                        float c3 = 0;
+                        memcpy(&c3,  &_inBuf[8], sizeof(float));
+
+                        float c4 = 0;
+                        memcpy(&c4,  &_inBuf[12], sizeof(float));
+
+                        float c5 = 0;
+                        memcpy(&c5,  &_inBuf[16], sizeof(float));
+
+                        float c6 = 0;
+                        memcpy(&c6,  &_inBuf[20], sizeof(float));
+
+                        handle_SET_RC_NORMAL_Request(c1, c2, c3, c4, c5, c6);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 228:
+                    {
+                        float batteryVoltage = 0;
+                        memcpy(&batteryVoltage,  &_inBuf[0], sizeof(float));
+
+                        handle_SET_BATTERY_VOLTAGE_Request(batteryVoltage);
+                        acknowledgeResponse();
+                        } break;
+
+                    case 9:
+                    {
+                        uint8_t meters = 0;
+                        uint8_t code = 0;
+                        handle_WP_CHANGE_ALTITUDE_Request(meters, code);
+                        prepareToSendBytes(2);
+                        sendByte(meters);
+                        sendByte(code);
+                        serialize8(_checksum);
+                        } break;
+
+                    case 26:
+                    {
+                        uint8_t hasPositionBoard = 0;
+                        handle_POSITION_BOARD_Request(hasPositionBoard);
+                        prepareToSendBytes(1);
+                        sendByte(hasPositionBoard);
+                        serialize8(_checksum);
+                        } break;
+
                 }
             }
 
             void dispatchDataMessage(void)
             {
                 switch (_command) {
+
+                    case 3:
+                    {
+                        uint8_t code = getArgument(0);
+                        handle_WP_LAND_Data(code);
+                        } break;
+
+                    case 27:
+                    {
+                        uint8_t positionBoardConnected = getArgument(0);
+                        handle_POSITION_BOARD_CONNECTED_Data(positionBoardConnected);
+                        } break;
 
                     case 102:
                     {
@@ -788,15 +818,11 @@ namespace hf {
                         handle_RAW_IMU_Data(accx, accy, accz, gyrx, gyry, gyrz, magx, magy, magz);
                         } break;
 
-                    case 121:
+                    case 199:
                     {
-                        float c1 = getArgument(0);
-                        float c2 = getArgument(1);
-                        float c3 = getArgument(2);
-                        float c4 = getArgument(3);
-                        float c5 = getArgument(4);
-                        float c6 = getArgument(5);
-                        handle_RC_NORMAL_Data(c1, c2, c3, c4, c5, c6);
+                        int32_t value1 = getArgument(0);
+                        int32_t value2 = getArgument(1);
+                        handle_FAKE_INT_Data(value1, value2);
                         } break;
 
                     case 122:
@@ -807,11 +833,49 @@ namespace hf {
                         handle_ATTITUDE_RADIANS_Data(roll, pitch, yaw);
                         } break;
 
-                    case 123:
+                    case 23:
                     {
-                        float estalt = getArgument(0);
-                        float vario = getArgument(1);
-                        handle_ALTITUDE_METERS_Data(estalt, vario);
+                        uint8_t flag = getArgument(0);
+                        handle_WP_MISSION_FLAG_Data(flag);
+                        } break;
+
+                    case 5:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_FORWARD_Data(meters, code);
+                        } break;
+
+                    case 30:
+                    {
+                        uint8_t flag = getArgument(0);
+                        handle_WP_MISSION_BEGIN_Data(flag);
+                        } break;
+
+                    case 0:
+                    {
+                        uint8_t code = getArgument(0);
+                        handle_CLEAR_EEPROM_Data(code);
+                        } break;
+
+                    case 8:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_RIGHT_Data(meters, code);
+                        } break;
+
+                    case 2:
+                    {
+                        uint8_t code = getArgument(0);
+                        handle_WP_DISARM_Data(code);
+                        } break;
+
+                    case 7:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_LEFT_Data(meters, code);
                         } break;
 
                     case 126:
@@ -822,11 +886,10 @@ namespace hf {
                         handle_LOITER_Data(agl, flowx, flowy);
                         } break;
 
-                    case 199:
+                    case 1:
                     {
-                        int32_t value1 = getArgument(0);
-                        int32_t value2 = getArgument(1);
-                        handle_FAKE_INT_Data(value1, value2);
+                        uint8_t code = getArgument(0);
+                        handle_WP_ARM_Data(code);
                         } break;
 
                     case 124:
@@ -838,84 +901,10 @@ namespace hf {
                         handle_GET_MOTOR_NORMAL_Data(m1, m2, m3, m4);
                         } break;
 
-                    case 0:
+                    case 24:
                     {
-                        uint8_t code = getArgument(0);
-                        handle_CLEAR_EEPROM_Data(code);
-                        } break;
-
-                    case 1:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_WP_ARM_Data(code);
-                        } break;
-
-                    case 2:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_WP_DISARM_Data(code);
-                        } break;
-
-                    case 3:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_WP_LAND_Data(code);
-                        } break;
-
-                    case 4:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_TAKE_OFF_Data(meters, code);
-                        } break;
-
-                    case 5:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_FORWARD_Data(meters, code);
-                        } break;
-
-                    case 6:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_BACKWARD_Data(meters, code);
-                        } break;
-
-                    case 7:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_LEFT_Data(meters, code);
-                        } break;
-
-                    case 8:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_GO_RIGHT_Data(meters, code);
-                        } break;
-
-                    case 9:
-                    {
-                        uint8_t meters = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_CHANGE_ALTITUDE_Data(meters, code);
-                        } break;
-
-                    case 10:
-                    {
-                        uint8_t speed = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_CHANGE_SPEED_Data(speed, code);
-                        } break;
-
-                    case 11:
-                    {
-                        uint8_t seconds = getArgument(0);
-                        uint8_t code = getArgument(1);
-                        handle_WP_HOVER_Data(seconds, code);
+                        uint8_t protocol = getArgument(0);
+                        handle_ESC_CALIBRATION_Data(protocol);
                         } break;
 
                     case 12:
@@ -925,47 +914,63 @@ namespace hf {
                         handle_WP_TURN_CW_Data(degrees, code);
                         } break;
 
+                    case 123:
+                    {
+                        float estalt = getArgument(0);
+                        float vario = getArgument(1);
+                        handle_ALTITUDE_METERS_Data(estalt, vario);
+                        } break;
+
+                    case 6:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_GO_BACKWARD_Data(meters, code);
+                        } break;
+
+                    case 121:
+                    {
+                        float c1 = getArgument(0);
+                        float c2 = getArgument(1);
+                        float c3 = getArgument(2);
+                        float c4 = getArgument(3);
+                        float c5 = getArgument(4);
+                        float c6 = getArgument(5);
+                        handle_RC_NORMAL_Data(c1, c2, c3, c4, c5, c6);
+                        } break;
+
+                    case 4:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_TAKE_OFF_Data(meters, code);
+                        } break;
+
+                    case 10:
+                    {
+                        uint8_t speed = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_CHANGE_SPEED_Data(speed, code);
+                        } break;
+
+                    case 125:
+                    {
+                        float voltage = getArgument(0);
+                        handle_GET_BATTERY_VOLTAGE_Data(voltage);
+                        } break;
+
+                    case 11:
+                    {
+                        uint8_t seconds = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_HOVER_Data(seconds, code);
+                        } break;
+
                     case 13:
                     {
                         uint8_t degrees = getArgument(0);
                         uint8_t code = getArgument(1);
                         handle_WP_TURN_CCW_Data(degrees, code);
-                        } break;
-
-                    case 23:
-                    {
-                        uint8_t flag = getArgument(0);
-                        handle_WP_MISSION_FLAG_Data(flag);
-                        } break;
-
-                    case 24:
-                    {
-                        uint8_t protocol = getArgument(0);
-                        handle_ESC_CALIBRATION_Data(protocol);
-                        } break;
-
-                    case 25:
-                    {
-                        uint8_t mosquitoVersion = getArgument(0);
-                        handle_MOSQUITO_VERSION_Data(mosquitoVersion);
-                        } break;
-
-                    case 26:
-                    {
-                        uint8_t hasPositionBoard = getArgument(0);
-                        handle_POSITION_BOARD_Data(hasPositionBoard);
-                        } break;
-
-                    case 27:
-                    {
-                        uint8_t positionBoardConnected = getArgument(0);
-                        handle_POSITION_BOARD_CONNECTED_Data(positionBoardConnected);
-                        } break;
-
-                    case 30:
-                    {
-                        uint8_t flag = getArgument(0);
-                        handle_WP_MISSION_BEGIN_Data(flag);
                         } break;
 
                     case 50:
@@ -974,10 +979,59 @@ namespace hf {
                         handle_FIRMWARE_VERSION_Data(version);
                         } break;
 
+                    case 25:
+                    {
+                        uint8_t mosquitoVersion = getArgument(0);
+                        handle_MOSQUITO_VERSION_Data(mosquitoVersion);
+                        } break;
+
+                    case 9:
+                    {
+                        uint8_t meters = getArgument(0);
+                        uint8_t code = getArgument(1);
+                        handle_WP_CHANGE_ALTITUDE_Data(meters, code);
+                        } break;
+
+                    case 26:
+                    {
+                        uint8_t hasPositionBoard = getArgument(0);
+                        handle_POSITION_BOARD_Data(hasPositionBoard);
+                        } break;
+
                 }
             }
 
         protected:
+
+            virtual void handle_WP_LAND_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_LAND_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & positionBoardConnected)
+            {
+                (void)positionBoardConnected;
+            }
+
+            virtual void handle_POSITION_BOARD_CONNECTED_Data(uint8_t & positionBoardConnected)
+            {
+                (void)positionBoardConnected;
+            }
+
+            virtual void handle_LOST_SIGNAL_Request(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_LOST_SIGNAL_Data(uint8_t  flag)
+            {
+                (void)flag;
+            }
 
             virtual void handle_RAW_IMU_Request(int16_t & accx, int16_t & accy, int16_t & accz, int16_t & gyrx, int16_t & gyry, int16_t & gyrz, int16_t & magx, int16_t & magy, int16_t & magz)
             {
@@ -1003,390 +1057,6 @@ namespace hf {
                 (void)magx;
                 (void)magy;
                 (void)magz;
-            }
-
-            virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6)
-            {
-                (void)c1;
-                (void)c2;
-                (void)c3;
-                (void)c4;
-                (void)c5;
-                (void)c6;
-            }
-
-            virtual void handle_RC_NORMAL_Data(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6)
-            {
-                (void)c1;
-                (void)c2;
-                (void)c3;
-                (void)c4;
-                (void)c5;
-                (void)c6;
-            }
-
-            virtual void handle_SET_RC_NORMAL_Request(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
-            {
-                (void)c1;
-                (void)c2;
-                (void)c3;
-                (void)c4;
-                (void)c5;
-                (void)c6;
-            }
-
-            virtual void handle_SET_RC_NORMAL_Data(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
-            {
-                (void)c1;
-                (void)c2;
-                (void)c3;
-                (void)c4;
-                (void)c5;
-                (void)c6;
-            }
-
-            virtual void handle_LOST_SIGNAL_Request(uint8_t  flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_LOST_SIGNAL_Data(uint8_t  flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_ATTITUDE_RADIANS_Request(float & roll, float & pitch, float & yaw)
-            {
-                (void)roll;
-                (void)pitch;
-                (void)yaw;
-            }
-
-            virtual void handle_ATTITUDE_RADIANS_Data(float & roll, float & pitch, float & yaw)
-            {
-                (void)roll;
-                (void)pitch;
-                (void)yaw;
-            }
-
-            virtual void handle_ALTITUDE_METERS_Request(float & estalt, float & vario)
-            {
-                (void)estalt;
-                (void)vario;
-            }
-
-            virtual void handle_ALTITUDE_METERS_Data(float & estalt, float & vario)
-            {
-                (void)estalt;
-                (void)vario;
-            }
-
-            virtual void handle_LOITER_Request(float & agl, float & flowx, float & flowy)
-            {
-                (void)agl;
-                (void)flowx;
-                (void)flowy;
-            }
-
-            virtual void handle_LOITER_Data(float & agl, float & flowx, float & flowy)
-            {
-                (void)agl;
-                (void)flowx;
-                (void)flowy;
-            }
-
-            virtual void handle_SET_ARMED_Request(uint8_t  flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_SET_ARMED_Data(uint8_t  flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_FAKE_INT_Request(int32_t & value1, int32_t & value2)
-            {
-                (void)value1;
-                (void)value2;
-            }
-
-            virtual void handle_FAKE_INT_Data(int32_t & value1, int32_t & value2)
-            {
-                (void)value1;
-                (void)value2;
-            }
-
-            virtual void handle_SET_MOTOR_NORMAL_Request(float  m1, float  m2, float  m3, float  m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_SET_MOTOR_NORMAL_Data(float  m1, float  m2, float  m3, float  m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_GET_MOTOR_NORMAL_Data(float & m1, float & m2, float & m3, float & m4)
-            {
-                (void)m1;
-                (void)m2;
-                (void)m3;
-                (void)m4;
-            }
-
-            virtual void handle_CLEAR_EEPROM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_CLEAR_EEPROM_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_ARM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_ARM_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_DISARM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_DISARM_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_LAND_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_LAND_Data(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_TAKE_OFF_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_FORWARD_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_BACKWARD_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_LEFT_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_GO_RIGHT_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_ALTITUDE_Data(uint8_t & meters, uint8_t & code)
-            {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code)
-            {
-                (void)speed;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_SPEED_Data(uint8_t & speed, uint8_t & code)
-            {
-                (void)speed;
-                (void)code;
-            }
-
-            virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code)
-            {
-                (void)seconds;
-                (void)code;
-            }
-
-            virtual void handle_WP_HOVER_Data(uint8_t & seconds, uint8_t & code)
-            {
-                (void)seconds;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CW_Data(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_TURN_CCW_Data(uint8_t & degrees, uint8_t & code)
-            {
-                (void)degrees;
-                (void)code;
-            }
-
-            virtual void handle_WP_MISSION_FLAG_Request(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_WP_MISSION_FLAG_Data(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_ESC_CALIBRATION_Request(uint8_t & protocol)
-            {
-                (void)protocol;
-            }
-
-            virtual void handle_ESC_CALIBRATION_Data(uint8_t & protocol)
-            {
-                (void)protocol;
-            }
-
-            virtual void handle_MOSQUITO_VERSION_Request(uint8_t & mosquitoVersion)
-            {
-                (void)mosquitoVersion;
-            }
-
-            virtual void handle_MOSQUITO_VERSION_Data(uint8_t & mosquitoVersion)
-            {
-                (void)mosquitoVersion;
-            }
-
-            virtual void handle_POSITION_BOARD_Request(uint8_t & hasPositionBoard)
-            {
-                (void)hasPositionBoard;
-            }
-
-            virtual void handle_POSITION_BOARD_Data(uint8_t & hasPositionBoard)
-            {
-                (void)hasPositionBoard;
-            }
-
-            virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & positionBoardConnected)
-            {
-                (void)positionBoardConnected;
-            }
-
-            virtual void handle_POSITION_BOARD_CONNECTED_Data(uint8_t & positionBoardConnected)
-            {
-                (void)positionBoardConnected;
-            }
-
-            virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_WP_MISSION_BEGIN_Data(uint8_t & flag)
-            {
-                (void)flag;
-            }
-
-            virtual void handle_FIRMWARE_VERSION_Request(uint8_t & version)
-            {
-                (void)version;
-            }
-
-            virtual void handle_FIRMWARE_VERSION_Data(uint8_t & version)
-            {
-                (void)version;
-            }
-
-            virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t  version)
-            {
-                (void)version;
-            }
-
-            virtual void handle_SET_MOSQUITO_VERSION_Data(uint8_t  version)
-            {
-                (void)version;
             }
 
             virtual void handle_SET_PID_CONSTANTS_Request(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
@@ -1429,14 +1099,16 @@ namespace hf {
                 (void)param9;
             }
 
-            virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
+            virtual void handle_FAKE_INT_Request(int32_t & value1, int32_t & value2)
             {
-                (void)hasBoard;
+                (void)value1;
+                (void)value2;
             }
 
-            virtual void handle_SET_POSITIONING_BOARD_Data(uint8_t  hasBoard)
+            virtual void handle_FAKE_INT_Data(int32_t & value1, int32_t & value2)
             {
-                (void)hasBoard;
+                (void)value1;
+                (void)value2;
             }
 
             virtual void handle_SET_LEDS_Request(uint8_t  red, uint8_t  green, uint8_t  blue)
@@ -1453,7 +1125,448 @@ namespace hf {
                 (void)blue;
             }
 
+            virtual void handle_ATTITUDE_RADIANS_Request(float & roll, float & pitch, float & yaw)
+            {
+                (void)roll;
+                (void)pitch;
+                (void)yaw;
+            }
+
+            virtual void handle_ATTITUDE_RADIANS_Data(float & roll, float & pitch, float & yaw)
+            {
+                (void)roll;
+                (void)pitch;
+                (void)yaw;
+            }
+
+            virtual void handle_WP_MISSION_FLAG_Request(uint8_t & flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_WP_MISSION_FLAG_Data(uint8_t & flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_FORWARD_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_SET_MOSQUITO_VERSION_Request(uint8_t  version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_SET_MOSQUITO_VERSION_Data(uint8_t  version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_SET_ARMED_Request(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_SET_ARMED_Data(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_WP_MISSION_BEGIN_Data(uint8_t & flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_CLEAR_EEPROM_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_CLEAR_EEPROM_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_RIGHT_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_DISARM_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_DISARM_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_LEFT_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_LOITER_Request(float & agl, float & flowx, float & flowy)
+            {
+                (void)agl;
+                (void)flowx;
+                (void)flowy;
+            }
+
+            virtual void handle_LOITER_Data(float & agl, float & flowx, float & flowy)
+            {
+                (void)agl;
+                (void)flowx;
+                (void)flowy;
+            }
+
+            virtual void handle_WP_ARM_Request(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_ARM_Data(uint8_t & code)
+            {
+                (void)code;
+            }
+
+            virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_GET_MOTOR_NORMAL_Data(float & m1, float & m2, float & m3, float & m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_ESC_CALIBRATION_Request(uint8_t & protocol)
+            {
+                (void)protocol;
+            }
+
+            virtual void handle_ESC_CALIBRATION_Data(uint8_t & protocol)
+            {
+                (void)protocol;
+            }
+
+            virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CW_Data(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_ALTITUDE_METERS_Request(float & estalt, float & vario)
+            {
+                (void)estalt;
+                (void)vario;
+            }
+
+            virtual void handle_ALTITUDE_METERS_Data(float & estalt, float & vario)
+            {
+                (void)estalt;
+                (void)vario;
+            }
+
+            virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_BACKWARD_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6)
+            {
+                (void)c1;
+                (void)c2;
+                (void)c3;
+                (void)c4;
+                (void)c5;
+                (void)c6;
+            }
+
+            virtual void handle_RC_NORMAL_Data(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6)
+            {
+                (void)c1;
+                (void)c2;
+                (void)c3;
+                (void)c4;
+                (void)c5;
+                (void)c6;
+            }
+
+            virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_TAKE_OFF_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code)
+            {
+                (void)speed;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_SPEED_Data(uint8_t & speed, uint8_t & code)
+            {
+                (void)speed;
+                (void)code;
+            }
+
+            virtual void handle_GET_BATTERY_VOLTAGE_Request(float & voltage)
+            {
+                (void)voltage;
+            }
+
+            virtual void handle_GET_BATTERY_VOLTAGE_Data(float & voltage)
+            {
+                (void)voltage;
+            }
+
+            virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code)
+            {
+                (void)seconds;
+                (void)code;
+            }
+
+            virtual void handle_WP_HOVER_Data(uint8_t & seconds, uint8_t & code)
+            {
+                (void)seconds;
+                (void)code;
+            }
+
+            virtual void handle_SET_MOTOR_NORMAL_Request(float  m1, float  m2, float  m3, float  m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_SET_MOTOR_NORMAL_Data(float  m1, float  m2, float  m3, float  m4)
+            {
+                (void)m1;
+                (void)m2;
+                (void)m3;
+                (void)m4;
+            }
+
+            virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t  hasBoard)
+            {
+                (void)hasBoard;
+            }
+
+            virtual void handle_SET_POSITIONING_BOARD_Data(uint8_t  hasBoard)
+            {
+                (void)hasBoard;
+            }
+
+            virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CCW_Data(uint8_t & degrees, uint8_t & code)
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_FIRMWARE_VERSION_Request(uint8_t & version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_FIRMWARE_VERSION_Data(uint8_t & version)
+            {
+                (void)version;
+            }
+
+            virtual void handle_MOSQUITO_VERSION_Request(uint8_t & mosquitoVersion)
+            {
+                (void)mosquitoVersion;
+            }
+
+            virtual void handle_MOSQUITO_VERSION_Data(uint8_t & mosquitoVersion)
+            {
+                (void)mosquitoVersion;
+            }
+
+            virtual void handle_SET_RC_NORMAL_Request(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                (void)c1;
+                (void)c2;
+                (void)c3;
+                (void)c4;
+                (void)c5;
+                (void)c6;
+            }
+
+            virtual void handle_SET_RC_NORMAL_Data(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                (void)c1;
+                (void)c2;
+                (void)c3;
+                (void)c4;
+                (void)c5;
+                (void)c6;
+            }
+
+            virtual void handle_SET_BATTERY_VOLTAGE_Request(float  batteryVoltage)
+            {
+                (void)batteryVoltage;
+            }
+
+            virtual void handle_SET_BATTERY_VOLTAGE_Data(float  batteryVoltage)
+            {
+                (void)batteryVoltage;
+            }
+
+            virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_ALTITUDE_Data(uint8_t & meters, uint8_t & code)
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_POSITION_BOARD_Request(uint8_t & hasPositionBoard)
+            {
+                (void)hasPositionBoard;
+            }
+
+            virtual void handle_POSITION_BOARD_Data(uint8_t & hasPositionBoard)
+            {
+                (void)hasPositionBoard;
+            }
+
         public:
+
+            static uint8_t serialize_WP_LAND_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 3;
+                bytes[5] = 3;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_LAND(uint8_t bytes[], uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 3;
+
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_POSITION_BOARD_CONNECTED_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 27;
+                bytes[5] = 27;
+
+                return 6;
+            }
+
+            static uint8_t serialize_POSITION_BOARD_CONNECTED(uint8_t bytes[], uint8_t  positionBoardConnected)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 27;
+
+                memcpy(&bytes[5], &positionBoardConnected, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_LOST_SIGNAL(uint8_t bytes[], uint8_t  flag)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 226;
+
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
 
             static uint8_t serialize_RAW_IMU_Request(uint8_t bytes[])
             {
@@ -1490,71 +1603,79 @@ namespace hf {
                 return 24;
             }
 
-            static uint8_t serialize_RC_NORMAL_Request(uint8_t bytes[])
+            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 64;
+                bytes[4] = 224;
+
+                memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
+                memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));
+                memcpy(&bytes[13], &gyroRollPitchD, sizeof(float));
+                memcpy(&bytes[17], &gyroYawP, sizeof(float));
+                memcpy(&bytes[21], &gyroYawI, sizeof(float));
+                memcpy(&bytes[25], &demandsToRate, sizeof(float));
+                memcpy(&bytes[29], &levelP, sizeof(float));
+                memcpy(&bytes[33], &altHoldP, sizeof(float));
+                memcpy(&bytes[37], &altHoldVelP, sizeof(float));
+                memcpy(&bytes[41], &altHoldVelI, sizeof(float));
+                memcpy(&bytes[45], &altHoldVelD, sizeof(float));
+                memcpy(&bytes[49], &minAltitude, sizeof(float));
+                memcpy(&bytes[53], &param6, sizeof(float));
+                memcpy(&bytes[57], &param7, sizeof(float));
+                memcpy(&bytes[61], &param8, sizeof(float));
+                memcpy(&bytes[65], &param9, sizeof(float));
+
+                bytes[69] = CRC8(&bytes[3], 66);
+
+                return 70;
+            }
+
+            static uint8_t serialize_FAKE_INT_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 121;
-                bytes[5] = 121;
+                bytes[4] = 199;
+                bytes[5] = 199;
 
                 return 6;
             }
 
-            static uint8_t serialize_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            static uint8_t serialize_FAKE_INT(uint8_t bytes[], int32_t  value1, int32_t  value2)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 24;
-                bytes[4] = 121;
+                bytes[3] = 8;
+                bytes[4] = 199;
 
-                memcpy(&bytes[5], &c1, sizeof(float));
-                memcpy(&bytes[9], &c2, sizeof(float));
-                memcpy(&bytes[13], &c3, sizeof(float));
-                memcpy(&bytes[17], &c4, sizeof(float));
-                memcpy(&bytes[21], &c5, sizeof(float));
-                memcpy(&bytes[25], &c6, sizeof(float));
+                memcpy(&bytes[5], &value1, sizeof(int32_t));
+                memcpy(&bytes[9], &value2, sizeof(int32_t));
 
-                bytes[29] = CRC8(&bytes[3], 26);
+                bytes[13] = CRC8(&bytes[3], 10);
 
-                return 30;
+                return 14;
             }
 
-            static uint8_t serialize_SET_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            static uint8_t serialize_SET_LEDS(uint8_t bytes[], uint8_t  red, uint8_t  green, uint8_t  blue)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 24;
-                bytes[4] = 222;
+                bytes[3] = 3;
+                bytes[4] = 227;
 
-                memcpy(&bytes[5], &c1, sizeof(float));
-                memcpy(&bytes[9], &c2, sizeof(float));
-                memcpy(&bytes[13], &c3, sizeof(float));
-                memcpy(&bytes[17], &c4, sizeof(float));
-                memcpy(&bytes[21], &c5, sizeof(float));
-                memcpy(&bytes[25], &c6, sizeof(float));
+                memcpy(&bytes[5], &red, sizeof(uint8_t));
+                memcpy(&bytes[6], &green, sizeof(uint8_t));
+                memcpy(&bytes[7], &blue, sizeof(uint8_t));
 
-                bytes[29] = CRC8(&bytes[3], 26);
+                bytes[8] = CRC8(&bytes[3], 5);
 
-                return 30;
-            }
-
-            static uint8_t serialize_LOST_SIGNAL(uint8_t bytes[], uint8_t  flag)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 226;
-
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
+                return 9;
             }
 
             static uint8_t serialize_ATTITUDE_RADIANS_Request(uint8_t bytes[])
@@ -1586,32 +1707,226 @@ namespace hf {
                 return 18;
             }
 
-            static uint8_t serialize_ALTITUDE_METERS_Request(uint8_t bytes[])
+            static uint8_t serialize_WP_MISSION_FLAG_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 123;
-                bytes[5] = 123;
+                bytes[4] = 23;
+                bytes[5] = 23;
 
                 return 6;
             }
 
-            static uint8_t serialize_ALTITUDE_METERS(uint8_t bytes[], float  estalt, float  vario)
+            static uint8_t serialize_WP_MISSION_FLAG(uint8_t bytes[], uint8_t  flag)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 8;
-                bytes[4] = 123;
+                bytes[3] = 1;
+                bytes[4] = 23;
 
-                memcpy(&bytes[5], &estalt, sizeof(float));
-                memcpy(&bytes[9], &vario, sizeof(float));
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
 
-                bytes[13] = CRC8(&bytes[3], 10);
+                bytes[6] = CRC8(&bytes[3], 3);
 
-                return 14;
+                return 7;
+            }
+
+            static uint8_t serialize_WP_GO_FORWARD_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 5;
+                bytes[5] = 5;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_GO_FORWARD(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 5;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_SET_MOSQUITO_VERSION(uint8_t bytes[], uint8_t  version)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 223;
+
+                memcpy(&bytes[5], &version, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_SET_ARMED(uint8_t bytes[], uint8_t  flag)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 216;
+
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_MISSION_BEGIN_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 30;
+                bytes[5] = 30;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_MISSION_BEGIN(uint8_t bytes[], uint8_t  flag)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 30;
+
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_CLEAR_EEPROM_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 0;
+                bytes[5] = 0;
+
+                return 6;
+            }
+
+            static uint8_t serialize_CLEAR_EEPROM(uint8_t bytes[], uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 0;
+
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_GO_RIGHT_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 8;
+                bytes[5] = 8;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_GO_RIGHT(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 8;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
+            static uint8_t serialize_WP_DISARM_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 2;
+                bytes[5] = 2;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_DISARM(uint8_t bytes[], uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 2;
+
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
+            }
+
+            static uint8_t serialize_WP_GO_LEFT_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 7;
+                bytes[5] = 7;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_GO_LEFT(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 7;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
             }
 
             static uint8_t serialize_LOITER_Request(uint8_t bytes[])
@@ -1643,65 +1958,31 @@ namespace hf {
                 return 18;
             }
 
-            static uint8_t serialize_SET_ARMED(uint8_t bytes[], uint8_t  flag)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 216;
-
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_FAKE_INT_Request(uint8_t bytes[])
+            static uint8_t serialize_WP_ARM_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 199;
-                bytes[5] = 199;
+                bytes[4] = 1;
+                bytes[5] = 1;
 
                 return 6;
             }
 
-            static uint8_t serialize_FAKE_INT(uint8_t bytes[], int32_t  value1, int32_t  value2)
+            static uint8_t serialize_WP_ARM(uint8_t bytes[], uint8_t  code)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 8;
-                bytes[4] = 199;
+                bytes[3] = 1;
+                bytes[4] = 1;
 
-                memcpy(&bytes[5], &value1, sizeof(int32_t));
-                memcpy(&bytes[9], &value2, sizeof(int32_t));
+                memcpy(&bytes[5], &code, sizeof(uint8_t));
 
-                bytes[13] = CRC8(&bytes[3], 10);
+                bytes[6] = CRC8(&bytes[3], 3);
 
-                return 14;
-            }
-
-            static uint8_t serialize_SET_MOTOR_NORMAL(uint8_t bytes[], float  m1, float  m2, float  m3, float  m4)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 16;
-                bytes[4] = 215;
-
-                memcpy(&bytes[5], &m1, sizeof(float));
-                memcpy(&bytes[9], &m2, sizeof(float));
-                memcpy(&bytes[13], &m3, sizeof(float));
-                memcpy(&bytes[17], &m4, sizeof(float));
-
-                bytes[21] = CRC8(&bytes[3], 18);
-
-                return 22;
+                return 7;
             }
 
             static uint8_t serialize_GET_MOTOR_NORMAL_Request(uint8_t bytes[])
@@ -1734,135 +2015,54 @@ namespace hf {
                 return 22;
             }
 
-            static uint8_t serialize_CLEAR_EEPROM_Request(uint8_t bytes[])
+            static uint8_t serialize_ESC_CALIBRATION_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 0;
-                bytes[5] = 0;
+                bytes[4] = 24;
+                bytes[5] = 24;
 
                 return 6;
             }
 
-            static uint8_t serialize_CLEAR_EEPROM(uint8_t bytes[], uint8_t  code)
+            static uint8_t serialize_ESC_CALIBRATION(uint8_t bytes[], uint8_t  protocol)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 1;
-                bytes[4] = 0;
+                bytes[4] = 24;
 
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
+                memcpy(&bytes[5], &protocol, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 
                 return 7;
             }
 
-            static uint8_t serialize_WP_ARM_Request(uint8_t bytes[])
+            static uint8_t serialize_WP_TURN_CW_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 1;
-                bytes[5] = 1;
+                bytes[4] = 12;
+                bytes[5] = 12;
 
                 return 6;
             }
 
-            static uint8_t serialize_WP_ARM(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 1;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_DISARM_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 2;
-                bytes[5] = 2;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_DISARM(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 2;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_LAND_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 3;
-                bytes[5] = 3;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_LAND(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 3;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_TAKE_OFF_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 4;
-                bytes[5] = 4;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_TAKE_OFF(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            static uint8_t serialize_WP_TURN_CW(uint8_t bytes[], uint8_t  degrees, uint8_t  code)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 2;
-                bytes[4] = 4;
+                bytes[4] = 12;
 
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[5], &degrees, sizeof(uint8_t));
                 memcpy(&bytes[6], &code, sizeof(uint8_t));
 
                 bytes[7] = CRC8(&bytes[3], 4);
@@ -1870,32 +2070,32 @@ namespace hf {
                 return 8;
             }
 
-            static uint8_t serialize_WP_GO_FORWARD_Request(uint8_t bytes[])
+            static uint8_t serialize_ALTITUDE_METERS_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 5;
-                bytes[5] = 5;
+                bytes[4] = 123;
+                bytes[5] = 123;
 
                 return 6;
             }
 
-            static uint8_t serialize_WP_GO_FORWARD(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            static uint8_t serialize_ALTITUDE_METERS(uint8_t bytes[], float  estalt, float  vario)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 5;
+                bytes[3] = 8;
+                bytes[4] = 123;
 
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
+                memcpy(&bytes[5], &estalt, sizeof(float));
+                memcpy(&bytes[9], &vario, sizeof(float));
 
-                bytes[7] = CRC8(&bytes[3], 4);
+                bytes[13] = CRC8(&bytes[3], 10);
 
-                return 8;
+                return 14;
             }
 
             static uint8_t serialize_WP_GO_BACKWARD_Request(uint8_t bytes[])
@@ -1926,81 +2126,57 @@ namespace hf {
                 return 8;
             }
 
-            static uint8_t serialize_WP_GO_LEFT_Request(uint8_t bytes[])
+            static uint8_t serialize_RC_NORMAL_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 7;
-                bytes[5] = 7;
+                bytes[4] = 121;
+                bytes[5] = 121;
 
                 return 6;
             }
 
-            static uint8_t serialize_WP_GO_LEFT(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            static uint8_t serialize_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 7;
+                bytes[3] = 24;
+                bytes[4] = 121;
 
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
+                memcpy(&bytes[5], &c1, sizeof(float));
+                memcpy(&bytes[9], &c2, sizeof(float));
+                memcpy(&bytes[13], &c3, sizeof(float));
+                memcpy(&bytes[17], &c4, sizeof(float));
+                memcpy(&bytes[21], &c5, sizeof(float));
+                memcpy(&bytes[25], &c6, sizeof(float));
 
-                bytes[7] = CRC8(&bytes[3], 4);
+                bytes[29] = CRC8(&bytes[3], 26);
 
-                return 8;
+                return 30;
             }
 
-            static uint8_t serialize_WP_GO_RIGHT_Request(uint8_t bytes[])
+            static uint8_t serialize_WP_TAKE_OFF_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 8;
-                bytes[5] = 8;
+                bytes[4] = 4;
+                bytes[5] = 4;
 
                 return 6;
             }
 
-            static uint8_t serialize_WP_GO_RIGHT(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            static uint8_t serialize_WP_TAKE_OFF(uint8_t bytes[], uint8_t  meters, uint8_t  code)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 2;
-                bytes[4] = 8;
-
-                memcpy(&bytes[5], &meters, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
-
-                bytes[7] = CRC8(&bytes[3], 4);
-
-                return 8;
-            }
-
-            static uint8_t serialize_WP_CHANGE_ALTITUDE_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 9;
-                bytes[5] = 9;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_CHANGE_ALTITUDE(uint8_t bytes[], uint8_t  meters, uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 9;
+                bytes[4] = 4;
 
                 memcpy(&bytes[5], &meters, sizeof(uint8_t));
                 memcpy(&bytes[6], &code, sizeof(uint8_t));
@@ -2038,6 +2214,33 @@ namespace hf {
                 return 8;
             }
 
+            static uint8_t serialize_GET_BATTERY_VOLTAGE_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 125;
+                bytes[5] = 125;
+
+                return 6;
+            }
+
+            static uint8_t serialize_GET_BATTERY_VOLTAGE(uint8_t bytes[], float  voltage)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 4;
+                bytes[4] = 125;
+
+                memcpy(&bytes[5], &voltage, sizeof(float));
+
+                bytes[9] = CRC8(&bytes[3], 6);
+
+                return 10;
+            }
+
             static uint8_t serialize_WP_HOVER_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
@@ -2066,32 +2269,37 @@ namespace hf {
                 return 8;
             }
 
-            static uint8_t serialize_WP_TURN_CW_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 12;
-                bytes[5] = 12;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_TURN_CW(uint8_t bytes[], uint8_t  degrees, uint8_t  code)
+            static uint8_t serialize_SET_MOTOR_NORMAL(uint8_t bytes[], float  m1, float  m2, float  m3, float  m4)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
-                bytes[3] = 2;
-                bytes[4] = 12;
+                bytes[3] = 16;
+                bytes[4] = 215;
 
-                memcpy(&bytes[5], &degrees, sizeof(uint8_t));
-                memcpy(&bytes[6], &code, sizeof(uint8_t));
+                memcpy(&bytes[5], &m1, sizeof(float));
+                memcpy(&bytes[9], &m2, sizeof(float));
+                memcpy(&bytes[13], &m3, sizeof(float));
+                memcpy(&bytes[17], &m4, sizeof(float));
 
-                bytes[7] = CRC8(&bytes[3], 4);
+                bytes[21] = CRC8(&bytes[3], 18);
 
-                return 8;
+                return 22;
+            }
+
+            static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 225;
+
+                memcpy(&bytes[5], &hasBoard, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
             }
 
             static uint8_t serialize_WP_TURN_CCW_Request(uint8_t bytes[])
@@ -2122,54 +2330,27 @@ namespace hf {
                 return 8;
             }
 
-            static uint8_t serialize_WP_MISSION_FLAG_Request(uint8_t bytes[])
+            static uint8_t serialize_FIRMWARE_VERSION_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 60;
                 bytes[3] = 0;
-                bytes[4] = 23;
-                bytes[5] = 23;
+                bytes[4] = 50;
+                bytes[5] = 50;
 
                 return 6;
             }
 
-            static uint8_t serialize_WP_MISSION_FLAG(uint8_t bytes[], uint8_t  flag)
+            static uint8_t serialize_FIRMWARE_VERSION(uint8_t bytes[], uint8_t  version)
             {
                 bytes[0] = 36;
                 bytes[1] = 77;
                 bytes[2] = 62;
                 bytes[3] = 1;
-                bytes[4] = 23;
+                bytes[4] = 50;
 
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_ESC_CALIBRATION_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 24;
-                bytes[5] = 24;
-
-                return 6;
-            }
-
-            static uint8_t serialize_ESC_CALIBRATION(uint8_t bytes[], uint8_t  protocol)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 24;
-
-                memcpy(&bytes[5], &protocol, sizeof(uint8_t));
+                memcpy(&bytes[5], &version, sizeof(uint8_t));
 
                 bytes[6] = CRC8(&bytes[3], 3);
 
@@ -2203,6 +2384,69 @@ namespace hf {
                 return 7;
             }
 
+            static uint8_t serialize_SET_RC_NORMAL(uint8_t bytes[], float  c1, float  c2, float  c3, float  c4, float  c5, float  c6)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 24;
+                bytes[4] = 222;
+
+                memcpy(&bytes[5], &c1, sizeof(float));
+                memcpy(&bytes[9], &c2, sizeof(float));
+                memcpy(&bytes[13], &c3, sizeof(float));
+                memcpy(&bytes[17], &c4, sizeof(float));
+                memcpy(&bytes[21], &c5, sizeof(float));
+                memcpy(&bytes[25], &c6, sizeof(float));
+
+                bytes[29] = CRC8(&bytes[3], 26);
+
+                return 30;
+            }
+
+            static uint8_t serialize_SET_BATTERY_VOLTAGE(uint8_t bytes[], float  batteryVoltage)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 4;
+                bytes[4] = 228;
+
+                memcpy(&bytes[5], &batteryVoltage, sizeof(float));
+
+                bytes[9] = CRC8(&bytes[3], 6);
+
+                return 10;
+            }
+
+            static uint8_t serialize_WP_CHANGE_ALTITUDE_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 9;
+                bytes[5] = 9;
+
+                return 6;
+            }
+
+            static uint8_t serialize_WP_CHANGE_ALTITUDE(uint8_t bytes[], uint8_t  meters, uint8_t  code)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 2;
+                bytes[4] = 9;
+
+                memcpy(&bytes[5], &meters, sizeof(uint8_t));
+                memcpy(&bytes[6], &code, sizeof(uint8_t));
+
+                bytes[7] = CRC8(&bytes[3], 4);
+
+                return 8;
+            }
+
             static uint8_t serialize_POSITION_BOARD_Request(uint8_t bytes[])
             {
                 bytes[0] = 36;
@@ -2228,164 +2472,6 @@ namespace hf {
                 bytes[6] = CRC8(&bytes[3], 3);
 
                 return 7;
-            }
-
-            static uint8_t serialize_POSITION_BOARD_CONNECTED_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 27;
-                bytes[5] = 27;
-
-                return 6;
-            }
-
-            static uint8_t serialize_POSITION_BOARD_CONNECTED(uint8_t bytes[], uint8_t  positionBoardConnected)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 27;
-
-                memcpy(&bytes[5], &positionBoardConnected, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_WP_MISSION_BEGIN_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 30;
-                bytes[5] = 30;
-
-                return 6;
-            }
-
-            static uint8_t serialize_WP_MISSION_BEGIN(uint8_t bytes[], uint8_t  flag)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 30;
-
-                memcpy(&bytes[5], &flag, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_FIRMWARE_VERSION_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 50;
-                bytes[5] = 50;
-
-                return 6;
-            }
-
-            static uint8_t serialize_FIRMWARE_VERSION(uint8_t bytes[], uint8_t  version)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 50;
-
-                memcpy(&bytes[5], &version, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_SET_MOSQUITO_VERSION(uint8_t bytes[], uint8_t  version)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 223;
-
-                memcpy(&bytes[5], &version, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_SET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 64;
-                bytes[4] = 224;
-
-                memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
-                memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));
-                memcpy(&bytes[13], &gyroRollPitchD, sizeof(float));
-                memcpy(&bytes[17], &gyroYawP, sizeof(float));
-                memcpy(&bytes[21], &gyroYawI, sizeof(float));
-                memcpy(&bytes[25], &demandsToRate, sizeof(float));
-                memcpy(&bytes[29], &levelP, sizeof(float));
-                memcpy(&bytes[33], &altHoldP, sizeof(float));
-                memcpy(&bytes[37], &altHoldVelP, sizeof(float));
-                memcpy(&bytes[41], &altHoldVelI, sizeof(float));
-                memcpy(&bytes[45], &altHoldVelD, sizeof(float));
-                memcpy(&bytes[49], &minAltitude, sizeof(float));
-                memcpy(&bytes[53], &param6, sizeof(float));
-                memcpy(&bytes[57], &param7, sizeof(float));
-                memcpy(&bytes[61], &param8, sizeof(float));
-                memcpy(&bytes[65], &param9, sizeof(float));
-
-                bytes[69] = CRC8(&bytes[3], 66);
-
-                return 70;
-            }
-
-            static uint8_t serialize_SET_POSITIONING_BOARD(uint8_t bytes[], uint8_t  hasBoard)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 225;
-
-                memcpy(&bytes[5], &hasBoard, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
-            }
-
-            static uint8_t serialize_SET_LEDS(uint8_t bytes[], uint8_t  red, uint8_t  green, uint8_t  blue)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 3;
-                bytes[4] = 227;
-
-                memcpy(&bytes[5], &red, sizeof(uint8_t));
-                memcpy(&bytes[6], &green, sizeof(uint8_t));
-                memcpy(&bytes[7], &blue, sizeof(uint8_t));
-
-                bytes[8] = CRC8(&bytes[3], 5);
-
-                return 9;
             }
 
     }; // class MspParser


### PR DESCRIPTION
## Functionality added
This PR aims to solve the problem described in issues #62 and #60, i.e., monitoring the battery voltage from Hackflight and detecting low battery.

This funcionality is specifically designed for the BonaDrone FC. In it, there is a voltage divider attached to an Analog pin (PIN33) of the ESP32. As we flash Hackflight into the STM32L4, we need the ESP32 to calculate and filter the voltage of the battery and send it over Serial to the STM32. With that aim we have also created an [Arduino sketch](https://github.com/BonaDrone/ESP32-Sketchs/tree/feat-battery_monitoring/ESP32-BonadroneFC) to be flashed into the ESP32. The voltage is encapsulated into an MSP message that is parsed by the MSP parser of the STM32.

In the Hackflight side, it has been implemented a simple `checkBattery()` that runs every loop. In it, the battery voltage is checked. The heuristics implemented check whether the voltage is lower than a certain threshold during certain seconds. If this is the case, a low voltage flag is triggered.

## Functionality that this PR does no address
This PR does not contain the action to be performed once the low battery flag is triggered. This is the aim of the issue #74.
