### PR TITLE
Fix Optical Flow correction in ESKF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,3 +37,5 @@
 * #49 Optical Flow connection pin
 * #51 Modify parameters at runtime (Mosquito version and Position Board presence)
 * #52 ESC calibration procedure
+* #77 Indexing of the Optical Flow's covariance matrix
+* #77 Inclusion of the Optical Flow in the ESKF sensor array

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -315,8 +315,8 @@ namespace hf {
 
                     hf::OpticalFlow * opticalflow = new hf::OpticalFlow();
                     bool _opticalConnected = opticalflow->begin();
-                    //h.addSensor(&opticalflow);
-                    //h.eskf.addSensorESKF(&opticalflow);
+                    h.addSensor(opticalflow);
+                    h.eskf.addSensorESKF(opticalflow);
                     
                     _positionBoardConnected = _rangeConnected & _opticalConnected;                 
                 }

--- a/src/sensors/opticalflow.hpp
+++ b/src/sensors/opticalflow.hpp
@@ -214,7 +214,7 @@ namespace hf {
             virtual void getCovarianceCorrection(float * R) override
             {
               R[0] = 5.0;
-              R[3] = 5.0;
+              R[4] = 5.0;
             }
             
             virtual void getMeasures(eskf_state_t & state) override


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

1. The Covariance matrix of the Optical Flow is built with wrong indexing. `R` is, by construction, a 3x3 matrix. If we want to fill the first row, first column and second row, second column positions the indexes should be `[0]`, `[4]` instead of `[0]`, `[3]`. 

2. Optical Flow is not being added to sensor array of the ESKF because the line that adds it is commented.

## Current behavior before PR

1. The Optical Flow covariance matrix (`R`) is built with wrong indexing. 
2. Optical Flow is not being added to sensor array of the ESKF.

## Desired behavior after PR is merged

1. The Optical Flow covariance matrix (`R`) is built with the proper indexing. 
2. Optical Flow, when present, is added to sensor array of the ESKF