### PR TITLE
Added Get/Set MSP methods to manage PID constants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 * #70 Transmitter calibration
 * #73 Battery monitoring and low battery trigger
 * #75 ESKF estimates horizontal positions and velocities as well as accelerometer bias
+* #79 MSP message to get PID constants
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -1,71 +1,71 @@
 {
-  "RAW_IMU": 
+  "RAW_IMU":
   [{"ID": 102},
-   {"accx": "short"}, 
-   {"accy": "short"}, 
-   {"accz": "short"}, 
-   {"gyrx": "short"}, 
-   {"gyry": "short"}, 
-   {"gyrz": "short"}, 
-   {"magx": "short"}, 
-   {"magy": "short"}, 
+   {"accx": "short"},
+   {"accy": "short"},
+   {"accz": "short"},
+   {"gyrx": "short"},
+   {"gyry": "short"},
+   {"gyrz": "short"},
+   {"magx": "short"},
+   {"magy": "short"},
    {"magz": "short"}],
 
-  "RC_NORMAL": 
+  "RC_NORMAL":
   [{"ID": 121},
-   {"comment": "16 channels in http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol"}, 
-   {"c1": "float"}, 
-   {"c2": "float"}, 
-   {"c3": "float"}, 
-   {"c4": "float"}, 
-   {"c5": "float"}, 
+   {"comment": "16 channels in http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol"},
+   {"c1": "float"},
+   {"c2": "float"},
+   {"c3": "float"},
+   {"c4": "float"},
+   {"c5": "float"},
    {"c6": "float"}],
 
-  "SET_RC_NORMAL": 
+  "SET_RC_NORMAL":
   [{"ID": 222},
-   {"c1": "float"}, 
-   {"c2": "float"}, 
-   {"c3": "float"}, 
-   {"c4": "float"}, 
-   {"c5": "float"}, 
+   {"c1": "float"},
+   {"c2": "float"},
+   {"c3": "float"},
+   {"c4": "float"},
+   {"c5": "float"},
    {"c6": "float"}],
 
-  "LOST_SIGNAL": 
+  "LOST_SIGNAL":
   [{"ID": 226},
-   {"comment": "ESP32 lost signal MSP message"}, 
+   {"comment": "ESP32 lost signal MSP message"},
    {"flag": "byte"}],
 
-  "ATTITUDE_RADIANS": 
+  "ATTITUDE_RADIANS":
   [{"ID": 122},
-   {"roll"    : "float"}, 
+   {"roll"    : "float"},
    {"pitch"   : "float"},
    {"yaw"     : "float"}],
-  
-  "ALTITUDE_METERS": 
+
+  "ALTITUDE_METERS":
   [{"ID": 123},
-   {"estalt"  : "float"}, 
-   {"vario"   : "float"}],  
+   {"estalt"  : "float"},
+   {"vario"   : "float"}],
 
-  "LOITER": 
+  "LOITER":
   [{"ID": 126},
-   {"agl"   : "float"}, 
+   {"agl"   : "float"},
    {"flowx" : "float"},
-   {"flowy" : "float"}],  
+   {"flowy" : "float"}],
 
-  "SET_ARMED": 
+  "SET_ARMED":
   [{"ID": 216},
-   {"comment": "Arm/disarm from MSP"}, 
+   {"comment": "Arm/disarm from MSP"},
    {"flag": "byte"}],
 
-  "FAKE_INT": 
+  "FAKE_INT":
   [{"ID": 199},
-   {"comment": "Fake int message for testing"}, 
+   {"comment": "Fake int message for testing"},
    {"value1" : "int"},
-   {"value2" : "int"}],  
+   {"value2" : "int"}],
 
-  "SET_MOTOR_NORMAL": 
+  "SET_MOTOR_NORMAL":
   [{"ID": 215},
-   {"comment": "We send floating-point values in [0,1], rather than PWM"}, 
+   {"comment": "We send floating-point values in [0,1], rather than PWM"},
    {"m1": "float"},
    {"m2": "float"},
    {"m3": "float"},
@@ -78,12 +78,12 @@
    {"m2": "float"},
    {"m3": "float"},
    {"m4": "float"}],
-   
+
   "CLEAR_EEPROM":
   [{"ID": 0},
    {"comment": "Clear all EEPROM memory"},
    {"code": "byte"}],
-    
+
   "WP_ARM":
   [{"ID": 1},
    {"comment": "Navigation order, arm the drone"},
@@ -93,7 +93,7 @@
   [{"ID": 2},
    {"comment": "Navigation order, disarm the drone"},
    {"code": "byte"}],
-   
+
   "WP_LAND":
   [{"ID": 3},
    {"comment": "Navigation order, land"},
@@ -173,7 +173,7 @@
   [{"ID": 25},
    {"comment": "Return the type of Mosquito (90 or 150)"},
    {"mosquitoVersion": "byte"}],
-  
+
   "POSITION_BOARD":
   [{"ID": 26},
    {"comment": "Return if position board parameter is set to True or False"},
@@ -187,18 +187,18 @@
   "WP_MISSION_BEGIN":
   [{"ID": 30},
    {"comment": "Start mission execution"},
-   {"flag": "byte"}], 
+   {"flag": "byte"}],
 
   "FIRMWARE_VERSION":
   [{"ID": 50},
    {"comment": "Current firmware version"},
    {"version": "byte"}],
-   
+
   "SET_MOSQUITO_VERSION":
   [{"ID": 223},
    {"comment": "Set the type of Mosquito (90 or 150) being used"},
-   {"version": "byte"}],  
-  
+   {"version": "byte"}],
+
   "SET_PID_CONSTANTS":
   [{"ID": 224},
    {"comment": "Set the controllers' parameters"},
@@ -218,19 +218,39 @@
    {"param7": "float"},
    {"param8": "float"},
    {"param9": "float"}],
-     
+
+   "GET_PID_CONSTANTS":
+   [{"ID": 127},
+    {"comment": "Get the controllers' parameters"},
+    {"gyroRollPitchP": "float"},
+    {"gyroRollPitchI": "float"},
+    {"gyroRollPitchD": "float"},
+    {"gyroYawP": "float"},
+    {"gyroYawI": "float"},
+    {"demandsToRate": "float"},
+    {"levelP": "float"},
+    {"altHoldP": "float"},
+    {"altHoldVelP": "float"},
+    {"altHoldVelI": "float"},
+    {"altHoldVelD": "float"},
+    {"minAltitude": "float"},
+    {"param6": "float"},
+    {"param7": "float"},
+    {"param8": "float"},
+    {"param9": "float"}],
+
   "SET_POSITIONING_BOARD":
   [{"ID": 225},
    {"comment": "Specify whether the positioning board is present or not"},
    {"hasBoard": "byte"}],
-   
+
   "SET_LEDS":
   [{"ID": 227},
    {"comment": "Specify whether the positioning board is present or not"},
    {"red": "byte"},
    {"green": "byte"},
    {"blue": "byte"}],
-   
+
   "RC_CALIBRATION":
   [{"ID": 214},
    {"comment": "Calibrate the transmitter"},
@@ -240,17 +260,17 @@
   [{"ID": 119},
    {"comment": "Return the status of the transmitter calibration"},
    {"status": "byte"}],
-   
+
   "SET_BATTERY_VOLTAGE":
   [{"ID": 228},
    {"comment": "Set the current voltage in the STM32 controller, measured in the ESP32"},
    {"batteryVoltage": "float"}],
-    
+
   "GET_BATTERY_VOLTAGE":
   [{"ID": 125},
    {"comment": "Get the current battery voltage"},
    {"voltage": "float"}],
-  
+
   "SET_RANGE_PARAMETERS":
   [{"ID": 221},
    {"comment": "Range calibration parameters, which is the translation from IMU to range frames"},

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -47,7 +47,7 @@ namespace hf {
 
         friend class HackflightWrapper;
 
-        private: 
+        private:
 
             // status variables
             // XXX use a proper version formating
@@ -57,7 +57,7 @@ namespace hf {
             bool _positionBoardConnected;
             // transmitter calibration
             tx_calibration_t _tx_calibration;
-            
+
             // Passed to Hackflight::init() for a particular build
             Board      * _board;
             Receiver   * _receiver;
@@ -76,7 +76,7 @@ namespace hf {
             Quaternion _quaternion; // not really a sensor, but we treat it like one!
             Accelerometer _accelerometer;
 
-            // Additional sensors 
+            // Additional sensors
             Sensor * _sensors[256];
             uint8_t _sensor_count;
 
@@ -90,7 +90,7 @@ namespace hf {
             bool _safeToArm;
             bool _failsafe;
             bool _lowBattery;
-            
+
             // XXX Store it as an MSP parameter
             const float _BAT_MIN = 3.3; // Minimum voltage for 1S Battery
 
@@ -101,17 +101,17 @@ namespace hf {
             {
                 return fabs(_state.UAVState->eulerAngles[axis]) < _ratePid->maxArmingAngle;
             }
-            
+
             void checkBattery()
             {
               // Frequency management
               static float lastTime = 0.0;
-              
+
               // Battery management
               static float lastTimeLowBattery = 0.0;
               static float lastBatteryVoltage = 0.0;
               static bool  isLastLowBattery = false;
-              
+
               // Check battery with a freq. of 2Hz
               if (_board->getTime() - lastTime > 0.5)
               {
@@ -120,11 +120,11 @@ namespace hf {
                 {
                   // Save the first time it detects low battery
                   lastTimeLowBattery = ((isLastLowBattery) ? lastTimeLowBattery:_board->getTime());
-                  
+
                   // Low battery if there has been low battery for more than 5s
                   // XXX it might be necessary to trigger the low battery action from here
                   _lowBattery = (_board->getTime() - lastTimeLowBattery > 5);
-                  
+
                   // ---- Provisional
                   if (_lowBattery)
                   {
@@ -132,7 +132,7 @@ namespace hf {
                     digitalWrite(25, LOW);
                   }
                   // ---- Provisional
-                  
+
                   isLastLowBattery = true;
                 }
                 else
@@ -141,12 +141,12 @@ namespace hf {
                 }
                 lastTime = _board->getTime();
               }
-                            
-              
+
+
             }
-            
+
             void updateControlSignal(void)
-            { 
+            {
                 // For PID control, start with demands from receiver
                 memcpy(&_demands, &_receiver->demands, sizeof(demands_t));
 
@@ -155,12 +155,12 @@ namespace hf {
                 // Use updated demands to run motors
                 if (_state.armed && !_failsafe && !_receiver->throttleIsDown()) {
                   _mixer->runArmed(_demands);
-                
+
                 }
             }
 
             void updateStateEstimate(void)
-            {                        
+            {
                 // Check all sensors if they need an update estimate
                 for (uint8_t k=0; k<eskf.sensor_count; ++k)
                 {
@@ -173,7 +173,7 @@ namespace hf {
                     }
                 }
             }
-            
+
             void correctStateEstimate(void)
             {
                 // Check all sensors if they need an update estimate
@@ -205,7 +205,7 @@ namespace hf {
                     float currentTime = _board->getTime();
 
                     // XXX we should allow associating PID controllers with particular aux states
-                    if (pidController->auxState <= auxState) {  
+                    if (pidController->auxState <= auxState) {
                         if (pidController->modifyDemands(*_state.UAVState, _demands, currentTime) && pidController->shouldFlashLed()) {
                             shouldFlash = true;
                         }
@@ -230,7 +230,7 @@ namespace hf {
                       _receiver->setBypassReceiver(false);
                     }
                 }
-            } 
+            }
 
             void checkReceiver(void)
             {
@@ -243,7 +243,7 @@ namespace hf {
                 // Disarm
                 if (_state.armed && !_receiver->getAux2State()) {
                     _state.armed = false;
-                } 
+                }
 
                 // Avoid arming if aux2 switch down on startup
                 if (!_safeToArm) {
@@ -252,11 +252,11 @@ namespace hf {
 
                 // Arm (after lots of safety checks!)
                 if (    _safeToArm &&
-                        !_state.armed && 
+                        !_state.armed &&
                         _receiver->throttleIsDown() &&
-                        _receiver->getAux2State() && 
-                        !_failsafe && 
-                        safeAngle(AXIS_ROLL) && 
+                        _receiver->getAux2State() &&
+                        !_failsafe &&
+                        safeAngle(AXIS_ROLL) &&
                         safeAngle(AXIS_PITCH)) {
                     _state.armed = true;
                     _yawInitial = _state.UAVState->eulerAngles[AXIS_YAW]; // grab yaw for headless mode
@@ -393,30 +393,30 @@ namespace hf {
                 _mixer->motorsDisarmed[2] = m3;
                 _mixer->motorsDisarmed[3] = m4;
             }
-            
+
             virtual void handle_CLEAR_EEPROM_Request(uint8_t & code) override
             {
-                for (int i = PARAMETER_SLOTS ; i < EEPROM.length() ; i++) 
+                for (int i = PARAMETER_SLOTS ; i < EEPROM.length() ; i++)
                 {
                     EEPROM.write(i, 0);
                 }
             }
-            
+
             virtual void handle_WP_MISSION_FLAG_Request(uint8_t & flag) override
             {
                 _board->flashLed(true);
                 delay(1000);
                 _board->flashLed(false);
             }
-            
+
             virtual void handle_WP_MISSION_BEGIN_Request(uint8_t & flag) override
             {
                 _state.executingMission = true;
             }
-            
+
             virtual void handle_FIRMWARE_VERSION_Request(uint8_t & version) override
             {
-                version = _firmwareVersion; 
+                version = _firmwareVersion;
             }
 
             virtual void handle_SET_RC_NORMAL_Request(float  c1, float  c2, float  c3, float  c4, float  c5, float  c6) override
@@ -432,7 +432,7 @@ namespace hf {
                 _receiver->setBypassReceiver(true);
                 _receiver->setLostSignal(false);
             }
-            
+
             virtual void handle_LOST_SIGNAL_Request(uint8_t  flag) override
             {
                 _receiver->setLostSignal(flag);
@@ -450,7 +450,7 @@ namespace hf {
                   _isMosquito90 = false;
                 }
             }
-            
+
             virtual void handle_SET_POSITIONING_BOARD_Request(uint8_t hasBoard) override
             {
                 uint8_t config = EEPROM.read(GENERAL_CONFIG);
@@ -463,7 +463,7 @@ namespace hf {
                   _hasPositioningBoard = false;
                 }
             }
-            
+
             virtual void handle_SET_PID_CONSTANTS_Request(float gyroRollPitchP,
                 float gyroRollPitchI, float gyroRollPitchD, float gyroYawP,
                 float gyroYawI, float demandsToRate, float levelP,
@@ -488,24 +488,49 @@ namespace hf {
                 EEPROM.put(PID_CONSTANTS + 14 * sizeof(float), param8);
                 EEPROM.put(PID_CONSTANTS + 15 * sizeof(float), param9);
             }
-            
+
+            virtual void handle_GET_PID_CONSTANTS_Request(float  & gyroRollPitchP,
+                float & gyroRollPitchI, float & gyroRollPitchD, float & gyroYawP,
+                float & gyroYawI, float & demandsToRate, float & levelP,
+                float & altHoldP, float & altHoldVelP, float & altHoldVelI, float & altHoldVelD,
+                float & minAltitude, float & param6, float & param7,
+                float & param8, float & param9) override
+            {
+              EEPROM.get(PID_CONSTANTS, gyroRollPitchP);
+              EEPROM.get(PID_CONSTANTS + 1 * sizeof(float), gyroRollPitchI);
+              EEPROM.get(PID_CONSTANTS + 2 * sizeof(float), gyroRollPitchD);
+              EEPROM.get(PID_CONSTANTS + 3 * sizeof(float), gyroYawP);
+              EEPROM.get(PID_CONSTANTS + 4 * sizeof(float), gyroYawI);
+              EEPROM.get(PID_CONSTANTS + 5 * sizeof(float), demandsToRate);
+              EEPROM.get(PID_CONSTANTS + 6 * sizeof(float), levelP);
+              EEPROM.get(PID_CONSTANTS + 7 * sizeof(float), altHoldP);
+              EEPROM.get(PID_CONSTANTS + 8 * sizeof(float), altHoldVelP);
+              EEPROM.get(PID_CONSTANTS + 9 * sizeof(float), altHoldVelI);
+              EEPROM.get(PID_CONSTANTS + 10 * sizeof(float), altHoldVelD);
+              EEPROM.get(PID_CONSTANTS + 11 * sizeof(float), minAltitude);
+              EEPROM.get(PID_CONSTANTS + 12 * sizeof(float), param6);
+              EEPROM.get(PID_CONSTANTS + 13 * sizeof(float), param7);
+              EEPROM.get(PID_CONSTANTS + 14 * sizeof(float), param8);
+              EEPROM.get(PID_CONSTANTS + 15 * sizeof(float), param9);
+            }
+
             virtual void handle_SET_RANGE_PARAMETERS_Request(float rx, float ry, float rz) override
             {
               EEPROM.put(RANGE_PARAMS, rx);
               EEPROM.put(RANGE_PARAMS + 1 * sizeof(float), ry);
               EEPROM.put(RANGE_PARAMS + 2 * sizeof(float), rz);
             }
-            
+
             virtual void handle_SET_BATTERY_VOLTAGE_Request(float  batteryVoltage) override
             {
               _state.batteryVoltage = batteryVoltage;
             }
-            
+
             virtual void handle_GET_BATTERY_VOLTAGE_Request(float & batteryVoltage) override
             {
                 batteryVoltage = _state.batteryVoltage;
             }
-            
+
             virtual void handle_GET_MOTOR_NORMAL_Request(float & m1, float & m2, float & m3, float & m4) override
             {
                   m1 = _mixer->motorsDisarmed[0];
@@ -513,22 +538,22 @@ namespace hf {
                   m3 = _mixer->motorsDisarmed[2];
                   m4 = _mixer->motorsDisarmed[3];
             }
-            
+
             virtual void handle_MOSQUITO_VERSION_Request(uint8_t & mosquitoVersion) override
             {
                 mosquitoVersion = _isMosquito90;
             }
-            
+
             virtual void handle_POSITION_BOARD_Request(uint8_t & hasPositionBoard) override
             {
                 hasPositionBoard = _hasPositioningBoard;
             }
-            
+
             virtual void handle_POSITION_BOARD_CONNECTED_Request(uint8_t & positionBoardConnected) override
             {
                 positionBoardConnected = _positionBoardConnected;
             }
-            
+
             virtual void handle_RC_CALIBRATION_Request(uint8_t stage) override
             {
                 switch (stage) {
@@ -562,7 +587,7 @@ namespace hf {
                           EEPROM.put(TRANSMITER_TRIMS + 3 * sizeof(float), _tx_calibration._center[0]);
                           EEPROM.put(TRANSMITER_TRIMS + 6 * sizeof(float), _tx_calibration._center[1]);
                           EEPROM.put(TRANSMITER_TRIMS + 9 * sizeof(float), _tx_calibration._center[2]);
-                          
+
                           doSerialComms();
                       }
                     }
@@ -599,7 +624,7 @@ namespace hf {
                           EEPROM.put(TRANSMITER_TRIMS + 7 * sizeof(float), _tx_calibration._max[2]);
                           EEPROM.put(TRANSMITER_TRIMS + 8 * sizeof(float), _tx_calibration._min[3]);
                           EEPROM.put(TRANSMITER_TRIMS + 10 * sizeof(float), _tx_calibration._max[3]);
-                          
+
                           doSerialComms();
                       }
 
@@ -618,7 +643,7 @@ namespace hf {
                     break;
                 }
             }
-            
+
             virtual void handle_RC_CALIBRATION_STATUS_Request(uint8_t & status) override
             {
                 status = _tx_calibration._rcCalibrationStatus;
@@ -627,25 +652,25 @@ namespace hf {
         public:
 
             void init(Board * board, Receiver * receiver, Mixer * mixer, Rate * ratePid, bool armed=false)
-            {  
+            {
                 // Store the essentials
                 _board    = board;
                 _receiver = receiver;
                 _mixer    = mixer;
                 _ratePid  = ratePid;
-                
+
                 // XXX Now, the order of the sensors and the ESKF sensor must be the same.
-                // XXX. Ideal behavior: add sensors and ensure a method (not harcoded) 
+                // XXX. Ideal behavior: add sensors and ensure a method (not harcoded)
                 // XXX that adds ESKF sensors depending on how they have been added in the sensors array.
-                
+
                 // Error state kalman filter
                 eskf.init();
                 eskf.addSensorESKF(&_imu);
                 eskf.addSensorESKF(&_accelerometer);
-                
+
                 // Support for mandatory sensors
                 addSensor(&_imu, board);
-                addSensor(&_accelerometer, board);      
+                addSensor(&_accelerometer, board);
 
                 // Last PID controller is always ratePid (rate), aux state = 0
                 addPidController(_ratePid, 0);
@@ -663,14 +688,14 @@ namespace hf {
 
                 // Initialize the receiver
                 _receiver->begin();
-                
+
                 // Initialize the planner
                 planner.init(PARAMETER_SLOTS);
                 // XXX Only for debuging purposes.
                 //planner.printMission();
 
                 // Tell the mixer which board to use
-                _mixer->board = board; 
+                _mixer->board = board;
 
                 // Setup failsafe
                 _failsafe = false;
@@ -684,19 +709,19 @@ namespace hf {
                 _positionBoardConnected = positionBoardConnected;
             }
 
-            void addSensor(PeripheralSensor * sensor) 
+            void addSensor(PeripheralSensor * sensor)
             {
                 add_sensor(sensor);
             }
 
-            void addSensor(SurfaceMountSensor * sensor, Board * board) 
+            void addSensor(SurfaceMountSensor * sensor, Board * board)
             {
                 add_sensor(sensor);
 
                 sensor->board = board;
             }
 
-            void addPidController(PID_Controller * pidController, uint8_t auxState) 
+            void addPidController(PID_Controller * pidController, uint8_t auxState)
             {
                 pidController->auxState = auxState;
                 _pid_controllers[_pid_controller_count++] = pidController;
@@ -706,7 +731,7 @@ namespace hf {
             {
                 // Check Battery
                 checkBattery();
-                
+
                 // Check planner
                 checkPlanner();
                 // Grab control signal if available
@@ -720,10 +745,10 @@ namespace hf {
                 // Compute control signal
                 checkFailsafe();
                 updateControlSignal();
-                
+
                 // XXX Only for debuging purposes
                 // readEEPROM();
-            } 
+            }
 
     }; // class Hackflight
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -743,6 +743,45 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 127:
+                    {
+                        float gyroRollPitchP = 0;
+                        float gyroRollPitchI = 0;
+                        float gyroRollPitchD = 0;
+                        float gyroYawP = 0;
+                        float gyroYawI = 0;
+                        float demandsToRate = 0;
+                        float levelP = 0;
+                        float altHoldP = 0;
+                        float altHoldVelP = 0;
+                        float altHoldVelI = 0;
+                        float altHoldVelD = 0;
+                        float minAltitude = 0;
+                        float param6 = 0;
+                        float param7 = 0;
+                        float param8 = 0;
+                        float param9 = 0;
+                        handle_GET_PID_CONSTANTS_Request(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate, levelP, altHoldP, altHoldVelP, altHoldVelI, altHoldVelD, minAltitude, param6, param7, param8, param9);
+                        prepareToSendFloats(16);
+                        sendFloat(gyroRollPitchP);
+                        sendFloat(gyroRollPitchI);
+                        sendFloat(gyroRollPitchD);
+                        sendFloat(gyroYawP);
+                        sendFloat(gyroYawI);
+                        sendFloat(demandsToRate);
+                        sendFloat(levelP);
+                        sendFloat(altHoldP);
+                        sendFloat(altHoldVelP);
+                        sendFloat(altHoldVelI);
+                        sendFloat(altHoldVelD);
+                        sendFloat(minAltitude);
+                        sendFloat(param6);
+                        sendFloat(param7);
+                        sendFloat(param8);
+                        sendFloat(param9);
+                        serialize8(_checksum);
+                        } break;
+
                     case 225:
                     {
                         uint8_t hasBoard = 0;
@@ -1023,6 +1062,27 @@ namespace hf {
                     {
                         uint8_t version = getArgument(0);
                         handle_FIRMWARE_VERSION_Data(version);
+                        } break;
+
+                    case 127:
+                    {
+                        float gyroRollPitchP = getArgument(0);
+                        float gyroRollPitchI = getArgument(1);
+                        float gyroRollPitchD = getArgument(2);
+                        float gyroYawP = getArgument(3);
+                        float gyroYawI = getArgument(4);
+                        float demandsToRate = getArgument(5);
+                        float levelP = getArgument(6);
+                        float altHoldP = getArgument(7);
+                        float altHoldVelP = getArgument(8);
+                        float altHoldVelI = getArgument(9);
+                        float altHoldVelD = getArgument(10);
+                        float minAltitude = getArgument(11);
+                        float param6 = getArgument(12);
+                        float param7 = getArgument(13);
+                        float param8 = getArgument(14);
+                        float param9 = getArgument(15);
+                        handle_GET_PID_CONSTANTS_Data(gyroRollPitchP, gyroRollPitchI, gyroRollPitchD, gyroYawP, gyroYawI, demandsToRate, levelP, altHoldP, altHoldVelP, altHoldVelI, altHoldVelD, minAltitude, param6, param7, param8, param9);
                         } break;
 
                     case 119:
@@ -1473,6 +1533,46 @@ namespace hf {
             }
 
             virtual void handle_SET_PID_CONSTANTS_Data(float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
+            {
+                (void)gyroRollPitchP;
+                (void)gyroRollPitchI;
+                (void)gyroRollPitchD;
+                (void)gyroYawP;
+                (void)gyroYawI;
+                (void)demandsToRate;
+                (void)levelP;
+                (void)altHoldP;
+                (void)altHoldVelP;
+                (void)altHoldVelI;
+                (void)altHoldVelD;
+                (void)minAltitude;
+                (void)param6;
+                (void)param7;
+                (void)param8;
+                (void)param9;
+            }
+
+            virtual void handle_GET_PID_CONSTANTS_Request(float & gyroRollPitchP, float & gyroRollPitchI, float & gyroRollPitchD, float & gyroYawP, float & gyroYawI, float & demandsToRate, float & levelP, float & altHoldP, float & altHoldVelP, float & altHoldVelI, float & altHoldVelD, float & minAltitude, float & param6, float & param7, float & param8, float & param9)
+            {
+                (void)gyroRollPitchP;
+                (void)gyroRollPitchI;
+                (void)gyroRollPitchD;
+                (void)gyroYawP;
+                (void)gyroYawI;
+                (void)demandsToRate;
+                (void)levelP;
+                (void)altHoldP;
+                (void)altHoldVelP;
+                (void)altHoldVelI;
+                (void)altHoldVelD;
+                (void)minAltitude;
+                (void)param6;
+                (void)param7;
+                (void)param8;
+                (void)param9;
+            }
+
+            virtual void handle_GET_PID_CONSTANTS_Data(float & gyroRollPitchP, float & gyroRollPitchI, float & gyroRollPitchD, float & gyroYawP, float & gyroYawI, float & demandsToRate, float & levelP, float & altHoldP, float & altHoldVelP, float & altHoldVelI, float & altHoldVelD, float & minAltitude, float & param6, float & param7, float & param8, float & param9)
             {
                 (void)gyroRollPitchP;
                 (void)gyroRollPitchI;
@@ -2450,6 +2550,48 @@ namespace hf {
                 bytes[2] = 62;
                 bytes[3] = 64;
                 bytes[4] = 224;
+
+                memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
+                memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));
+                memcpy(&bytes[13], &gyroRollPitchD, sizeof(float));
+                memcpy(&bytes[17], &gyroYawP, sizeof(float));
+                memcpy(&bytes[21], &gyroYawI, sizeof(float));
+                memcpy(&bytes[25], &demandsToRate, sizeof(float));
+                memcpy(&bytes[29], &levelP, sizeof(float));
+                memcpy(&bytes[33], &altHoldP, sizeof(float));
+                memcpy(&bytes[37], &altHoldVelP, sizeof(float));
+                memcpy(&bytes[41], &altHoldVelI, sizeof(float));
+                memcpy(&bytes[45], &altHoldVelD, sizeof(float));
+                memcpy(&bytes[49], &minAltitude, sizeof(float));
+                memcpy(&bytes[53], &param6, sizeof(float));
+                memcpy(&bytes[57], &param7, sizeof(float));
+                memcpy(&bytes[61], &param8, sizeof(float));
+                memcpy(&bytes[65], &param9, sizeof(float));
+
+                bytes[69] = CRC8(&bytes[3], 66);
+
+                return 70;
+            }
+
+            static uint8_t serialize_GET_PID_CONSTANTS_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 127;
+                bytes[5] = 127;
+
+                return 6;
+            }
+
+            static uint8_t serialize_GET_PID_CONSTANTS(uint8_t bytes[], float  gyroRollPitchP, float  gyroRollPitchI, float  gyroRollPitchD, float  gyroYawP, float  gyroYawI, float  demandsToRate, float  levelP, float  altHoldP, float  altHoldVelP, float  altHoldVelI, float  altHoldVelD, float  minAltitude, float  param6, float  param7, float  param8, float  param9)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 64;
+                bytes[4] = 127;
 
                 memcpy(&bytes[5], &gyroRollPitchP, sizeof(float));
                 memcpy(&bytes[9], &gyroRollPitchI, sizeof(float));


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

1. Add MSP messages (Get/Set) to manage PID parameters using serial comms.

## Current behavior before PR

Only set method was implemented

## Desired behavior after PR is merged

Get/Set PID parameters using MSP messages.