### PR TITLE
Enable clearing EEPROM by sections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 * #43 Update file headers
 * #75 Refactor tasks in main loop
 * #76 Improve Rate and Level controllers 
+* #80 Enable clearing EEPROM by sections
 
 ### Removed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -79,11 +79,6 @@
    {"m3": "float"},
    {"m4": "float"}],
 
-  "CLEAR_EEPROM":
-  [{"ID": 0},
-   {"comment": "Clear all EEPROM memory"},
-   {"code": "byte"}],
-
   "WP_ARM":
   [{"ID": 1},
    {"comment": "Navigation order, arm the drone"},
@@ -276,6 +271,11 @@
    {"comment": "Range calibration parameters, which is the translation from IMU to range frames"},
    {"rx": "float"},
    {"ry": "float"},
-   {"rz": "float"}]
+   {"rz": "float"}],
+   
+  "CLEAR_EEPROM":
+  [{"ID": 201},
+   {"comment": "Clear a specific section of the EEPROM (or all)"},
+   {"section": "byte"}]
 
 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -394,12 +394,29 @@ namespace hf {
                 _mixer->motorsDisarmed[3] = m4;
             }
 
-            virtual void handle_CLEAR_EEPROM_Request(uint8_t & code) override
+            virtual void handle_CLEAR_EEPROM_Request(uint8_t section) override
             {
-                for (int i = PARAMETER_SLOTS ; i < EEPROM.length() ; i++)
-                {
-                    EEPROM.write(i, 0);
+                switch (section) {
+                  case 0: // Clear parameters section
+                      for (int i=0; i<PARAMETER_SLOTS; i++)
+                      {
+                          EEPROM.write(i, 0);
+                      }
+                      break;
+                  case 1: // Clear mission section
+                      for (int i=PARAMETER_SLOTS; i<EEPROM.length(); i++)
+                      {
+                          EEPROM.write(i, 0);
+                      }
+                      break;
+                  case 2: // Clear all
+                      for (int i=0; i<EEPROM.length(); i++)
+                      {
+                          EEPROM.write(i, 0);
+                      }
+                      break;
                 }
+
             }
 
             virtual void handle_WP_MISSION_FLAG_Request(uint8_t & flag) override

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -470,15 +470,6 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
-                    case 0:
-                    {
-                        uint8_t code = 0;
-                        handle_CLEAR_EEPROM_Request(code);
-                        prepareToSendBytes(1);
-                        sendByte(code);
-                        serialize8(_checksum);
-                        } break;
-
                     case 1:
                     {
                         uint8_t code = 0;
@@ -857,6 +848,15 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 201:
+                    {
+                        uint8_t section = 0;
+                        memcpy(&section,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_CLEAR_EEPROM_Request(section);
+                        acknowledgeResponse();
+                        } break;
+
                 }
             }
 
@@ -926,12 +926,6 @@ namespace hf {
                         float m3 = getArgument(2);
                         float m4 = getArgument(3);
                         handle_GET_MOTOR_NORMAL_Data(m1, m2, m3, m4);
-                        } break;
-
-                    case 0:
-                    {
-                        uint8_t code = getArgument(0);
-                        handle_CLEAR_EEPROM_Data(code);
                         } break;
 
                     case 1:
@@ -1270,16 +1264,6 @@ namespace hf {
                 (void)m2;
                 (void)m3;
                 (void)m4;
-            }
-
-            virtual void handle_CLEAR_EEPROM_Request(uint8_t & code)
-            {
-                (void)code;
-            }
-
-            virtual void handle_CLEAR_EEPROM_Data(uint8_t & code)
-            {
-                (void)code;
             }
 
             virtual void handle_WP_ARM_Request(uint8_t & code)
@@ -1670,6 +1654,16 @@ namespace hf {
                 (void)rz;
             }
 
+            virtual void handle_CLEAR_EEPROM_Request(uint8_t  section)
+            {
+                (void)section;
+            }
+
+            virtual void handle_CLEAR_EEPROM_Data(uint8_t  section)
+            {
+                (void)section;
+            }
+
         public:
 
             static uint8_t serialize_RAW_IMU_Request(uint8_t bytes[])
@@ -1949,33 +1943,6 @@ namespace hf {
                 bytes[21] = CRC8(&bytes[3], 18);
 
                 return 22;
-            }
-
-            static uint8_t serialize_CLEAR_EEPROM_Request(uint8_t bytes[])
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 60;
-                bytes[3] = 0;
-                bytes[4] = 0;
-                bytes[5] = 0;
-
-                return 6;
-            }
-
-            static uint8_t serialize_CLEAR_EEPROM(uint8_t bytes[], uint8_t  code)
-            {
-                bytes[0] = 36;
-                bytes[1] = 77;
-                bytes[2] = 62;
-                bytes[3] = 1;
-                bytes[4] = 0;
-
-                memcpy(&bytes[5], &code, sizeof(uint8_t));
-
-                bytes[6] = CRC8(&bytes[3], 3);
-
-                return 7;
             }
 
             static uint8_t serialize_WP_ARM_Request(uint8_t bytes[])
@@ -2746,6 +2713,21 @@ namespace hf {
                 bytes[17] = CRC8(&bytes[3], 14);
 
                 return 18;
+            }
+
+            static uint8_t serialize_CLEAR_EEPROM(uint8_t bytes[], uint8_t  section)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 201;
+
+                memcpy(&bytes[5], &section, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
             }
 
     }; // class MspParser


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When entering DFU mode via hardware (using the BTN on the board) the whole EEPROM of the board is reset to 255. This results in some configuration parameters of the Mosquito (bits of EEPROM register at address 0 - `GENERAL_CONFIG` -) being set to `True` when the desired value is `False` ( for example: `TX_CALIBRATED`, `ESC_CALIBRATION`). To avoid this side-effect, the EEPROM should be cleared by writing 0s to all the addresses after loading the firmware and before loading the parameters.

To do so, a new method that clears sections or the whole EEPROM has been implemented. This method can be triggered via MSP and via a flag that can take the values 0, 1 or 2 clears a specific section of the EEPROM. The relation is:
1. Clear parameters section
2. Clear mission section
3. Clear the whole EEPROM

## Current behavior before PR

There is no method to clear the EEPROM or sections of it.

When the firmware is loaded the whole EEPROM is reset and all the addresses contain the value 255. As explained in the previous section, this results in unwanted side effects. 

## Desired behavior after PR is merged

There is a method to clear the EEPROM or sections of it.
