### PR TITLE
Flight mission completed MSP check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 * #73 Battery monitoring and low battery trigger
 * #75 ESKF estimates horizontal positions and velocities as well as accelerometer bias
 * #79 MSP message to get PID constants
+* #95 MSP message to retrieve flight mission execution status
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -272,6 +272,11 @@
    {"comment": "Get the current battery voltage"},
    {"voltage": "float"}],
 
+  "GET_MISSION_COMPLETE":
+  [{"ID": 116},
+   {"comment": "Get the status of the flight mission execution"},
+   {"status": "byte"}],
+
   "SET_RANGE_PARAMETERS":
   [{"ID": 221},
    {"comment": "Range calibration parameters, which is the translation from IMU to range frames"},

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -671,6 +671,11 @@ namespace hf {
                 status = _tx_calibration._rcCalibrationStatus;
             }
 
+            virtual void handle_GET_MISSION_COMPLETE_Request(uint8_t & status) override
+            {
+                status = _state.executingMission ? 1 : 0;
+            }
+
         public:
 
             void init(Board * board, Receiver * receiver, Mixer * mixer, Rate * ratePid, bool armed=false)

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -848,6 +848,15 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
+                    case 116:
+                    {
+                        uint8_t status = 0;
+                        handle_GET_MISSION_COMPLETE_Request(status);
+                        prepareToSendBytes(1);
+                        sendByte(status);
+                        serialize8(_checksum);
+                        } break;
+
                     case 221:
                     {
                         float rx = 0;
@@ -1107,6 +1116,12 @@ namespace hf {
                     {
                         float voltage = getArgument(0);
                         handle_GET_BATTERY_VOLTAGE_Data(voltage);
+                        } break;
+
+                    case 116:
+                    {
+                        uint8_t status = getArgument(0);
+                        handle_GET_MISSION_COMPLETE_Data(status);
                         } break;
 
                 }
@@ -1668,6 +1683,16 @@ namespace hf {
             virtual void handle_GET_BATTERY_VOLTAGE_Data(float & voltage)
             {
                 (void)voltage;
+            }
+
+            virtual void handle_GET_MISSION_COMPLETE_Request(uint8_t & status)
+            {
+                (void)status;
+            }
+
+            virtual void handle_GET_MISSION_COMPLETE_Data(uint8_t & status)
+            {
+                (void)status;
             }
 
             virtual void handle_SET_RANGE_PARAMETERS_Request(float  rx, float  ry, float  rz)
@@ -2732,6 +2757,33 @@ namespace hf {
                 bytes[9] = CRC8(&bytes[3], 6);
 
                 return 10;
+            }
+
+            static uint8_t serialize_GET_MISSION_COMPLETE_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 116;
+                bytes[5] = 116;
+
+                return 6;
+            }
+
+            static uint8_t serialize_GET_MISSION_COMPLETE(uint8_t bytes[], uint8_t  status)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 116;
+
+                memcpy(&bytes[5], &status, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
             }
 
             static uint8_t serialize_SET_RANGE_PARAMETERS(uint8_t bytes[], float  rx, float  ry, float  rz)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #81 

This PR adds a new MSP message so that the current status of the flight mission execution can be queried from the platform. The query returns `1` if the execution has finished or if the drone is idle and `0` if a mission is being executed.

## Current behavior before PR

There is no way to know if the Mosquito is executing a mission or not.

## Desired behavior after PR is merged

The platform is able to retrieve the status of the flight mission execution.
