### PR TITLE
Emergency stop via MSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 * #75 ESKF estimates horizontal positions and velocities as well as accelerometer bias
 * #79 MSP message to get PID constants
 * #95 MSP message to retrieve flight mission execution status
+* #96 MSP message to stop the Mosquito
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -267,6 +267,11 @@
    {"comment": "Set the current voltage in the STM32 controller, measured in the ESP32"},
    {"batteryVoltage": "float"}],
 
+  "SET_EMERGENCY_STOP":
+  [{"ID": 229},
+   {"comment": "Trigger an emergency landing"},
+   {"flag": "byte"}],
+
   "GET_BATTERY_VOLTAGE":
   [{"ID": 125},
    {"comment": "Get the current battery voltage"},

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -675,6 +675,13 @@ namespace hf {
             {
                 status = _state.executingMission ? 1 : 0;
             }
+            
+            virtual void handle_SET_EMERGENCY_STOP_Request(uint8_t  flag)
+            {
+                // XXX This should trigger a land action 
+                (void)flag;
+                digitalWrite(25, LOW);
+            }
 
         public:
 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -839,6 +839,15 @@ namespace hf {
                         acknowledgeResponse();
                         } break;
 
+                    case 229:
+                    {
+                        uint8_t flag = 0;
+                        memcpy(&flag,  &_inBuf[0], sizeof(uint8_t));
+
+                        handle_SET_EMERGENCY_STOP_Request(flag);
+                        acknowledgeResponse();
+                        } break;
+
                     case 125:
                     {
                         float voltage = 0;
@@ -1673,6 +1682,16 @@ namespace hf {
             virtual void handle_SET_BATTERY_VOLTAGE_Data(float  batteryVoltage)
             {
                 (void)batteryVoltage;
+            }
+
+            virtual void handle_SET_EMERGENCY_STOP_Request(uint8_t  flag)
+            {
+                (void)flag;
+            }
+
+            virtual void handle_SET_EMERGENCY_STOP_Data(uint8_t  flag)
+            {
+                (void)flag;
             }
 
             virtual void handle_GET_BATTERY_VOLTAGE_Request(float & voltage)
@@ -2730,6 +2749,21 @@ namespace hf {
                 bytes[9] = CRC8(&bytes[3], 6);
 
                 return 10;
+            }
+
+            static uint8_t serialize_SET_EMERGENCY_STOP(uint8_t bytes[], uint8_t  flag)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 1;
+                bytes[4] = 229;
+
+                memcpy(&bytes[5], &flag, sizeof(uint8_t));
+
+                bytes[6] = CRC8(&bytes[3], 3);
+
+                return 7;
             }
 
             static uint8_t serialize_GET_BATTERY_VOLTAGE_Request(uint8_t bytes[])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #87 

This PR adds a new MSP message to trigger an emergency landing via MSP. This enables to stop the Mosquito from the platform. 

## Current behavior before PR

There is no way to stop the execution of a mission from the platform.

## Desired behavior after PR is merged

The platform is able to stop the execution/flight of the Mosquito via MSP. (Currently it just turns on the red LED)