### PR TITLE
Allow to specify MSP messages that do not acknowledge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 * #102 Filter OF measures with a LPF
 * #102 Express linear velocities in IMU frame
 * #102 ESKF tuning and cleanup
+* #103 Allow to define MSP messages with ID > 200 that do not acknowledge
 
 ### Changed
 

--- a/extras/parser/msppg.py
+++ b/extras/parser/msppg.py
@@ -26,6 +26,10 @@ import os
 import json
 from pkg_resources import resource_string
 
+# Constants ==================================================================================
+
+AVOID_ACKNOWLEDGE = [228]
+
 # Helper functions ===========================================================================
 
 def clean(string):
@@ -275,7 +279,8 @@ class HPP_Emitter(CodeEmitter):
                     self.output.write(6*self.indent + ('send%s(%s);\n' % (argtype, argname)))
                 self.output.write(6*self.indent + "serialize8(_checksum);\n")
             else:
-                self.output.write(6*self.indent + "acknowledgeResponse();\n")
+            	if msgid not in AVOID_ACKNOWLEDGE: 
+                	self.output.write(6*self.indent + "acknowledgeResponse();\n")
             self.output.write(6*self.indent + '} break;\n\n')
 
         self.output.write(4*self.indent + '}\n')

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -836,7 +836,6 @@ namespace hf {
                         memcpy(&batteryVoltage,  &_inBuf[0], sizeof(float));
 
                         handle_SET_BATTERY_VOLTAGE_Request(batteryVoltage);
-                        acknowledgeResponse();
                         } break;
 
                     case 229:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When generating the `mspparser` code allow to specify a set of messages that do not acknowledge.

## Current behavior before PR

Any message with ID > 200 acknowledged by default.

## Desired behavior after PR is merged

messages with ID > 200 that do not acknowledge can be defined. To do so, add the message ID to the `AVOID_ACKNOWLEDGE` list in `Hackflight/extras/parser/msppg.py`