### PR TITLE
Filter ESKF estimated linear velocities with a LPF (+tuning)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 * #102 Express linear velocities in IMU frame
 * #102 ESKF tuning and cleanup
 * #103 Allow to define MSP messages with ID > 200 that do not acknowledge
+* #105 Filter ESKF estimated linear velocities with a LPF
 
 ### Changed
 

--- a/src/sensors/imu.hpp
+++ b/src/sensors/imu.hpp
@@ -380,7 +380,7 @@ namespace hf {
                 Q[3] =  0;
                 Q[18] =   0;
                 Q[33] =   0;
-                Q[48] =   5.0;
+                Q[48] =   20.0;
                 Q[63] =   0;
                 Q[78] =   0;
                 Q[93] =   0;
@@ -397,7 +397,7 @@ namespace hf {
                 Q[19] =  0;
                 Q[34] =   0;
                 Q[49] =   0;
-                Q[64] =   5.0;
+                Q[64] =   20.0;
                 Q[79] =   0;
                 Q[94] =   0;
                 Q[109] =   0;
@@ -414,7 +414,7 @@ namespace hf {
                 Q[35] =  0;
                 Q[50] =   0;
                 Q[65] =   0;
-                Q[80] =   5.0;
+                Q[80] =   1.0;
                 Q[95] =   0;
                 Q[110] =   0;
                 Q[125] =   0;
@@ -586,9 +586,9 @@ namespace hf {
             {
                 (void)time;
 
-                bool result = board->getIMU(_rates, _accels);
+                board->getIMU(_rates, _accels);
 
-                return result;
+                return true;
             }
 
         private:

--- a/src/sensors/opticalflow.hpp
+++ b/src/sensors/opticalflow.hpp
@@ -50,7 +50,7 @@ namespace hf {
             // Time elapsed between corrections
             float deltat = 0.0;
             // Focal distance 
-            float f = 375.0;
+            float f = 350.0;
             // angular velocities
             float _rates[3];
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #67 

* Filter estimated linear velocities with a LPF
* Tune filter parameters regarding linear velocity estimation

## Current behavior before PR

Estimated linear velocities were not treated and this resulted in noisy estimations.

## Desired behavior after PR is merged

The estimation of linear velocities is smoother and close to the real values.
