### PR TITLE
Main loop improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 * #75 Refactor tasks in main loop
 * #76 Improve Rate and Level controllers 
 * #80 Enable clearing EEPROM by sections
+* #107 Increase main loop speed
 
 ### Removed
 

--- a/examples/Bonadrone/Parametrized/Parametrized.ino
+++ b/examples/Bonadrone/Parametrized/Parametrized.ino
@@ -10,5 +10,5 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-  hw.update();
+  hw.h.update();
 }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Increase the speed at which the main loop runs by directly calling Hackflight's update.

## Current behavior before PR

The main loop was considerably slower (running at 60Hz instead of 160Hz) due to nested `update` calls.

## Desired behavior after PR is merged

The main loop runs at 160Hz again. This is achieved by removing the intermediate `update` call and calling directly Hackflight's update from the main Arduino `loop` function.

