### PR TITLE
Enable immediate execution of actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 * #104 Vertical velocity control when in Altitude Hold mode and outside of the deadband 
 * #105 Filter ESKF estimated linear velocities with a LPF
 * #116 Enable immediate execution of actions
+* #116 When executing a flight mission, switching the value of the aux 1 in the remote returns the control of the drone to the TX or APP
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 * #103 Allow to define MSP messages with ID > 200 that do not acknowledge
 * #104 Vertical velocity control when in Altitude Hold mode and outside of the deadband 
 * #105 Filter ESKF estimated linear velocities with a LPF
+* #116 Enable immediate execution of actions
 
 ### Changed
 

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -38,6 +38,7 @@ typedef struct {
     hf::eskf_state_t * UAVState;  // Mosquito status 
     bool  armed;
     bool  executingMission;
+    bool  executingStack;
     float batteryVoltage;         // current Voltage
 } state_t;
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -40,6 +40,7 @@
 #include "filters/eskf.hpp"
 
 #include "planners/mission.hpp"
+#include "planners/individual.hpp"
 
 namespace hf {
 
@@ -59,11 +60,12 @@ namespace hf {
             tx_calibration_t _tx_calibration;
 
             // Passed to Hackflight::init() for a particular build
-            Board      * _board;
-            Receiver   * _receiver;
-            Rate       * _ratePid;
-            Mixer      * _mixer;
+            Board               * _board;
+            Receiver            * _receiver;
+            Rate                * _ratePid;
+            Mixer               * _mixer;
             MissionPlanner      planner;
+            IndividualPlanner   individualPlanner;
 
             ESKF eskf = ESKF();
 
@@ -728,6 +730,8 @@ namespace hf {
                 _state.armed = armed;
                 // Will be set to true when start mission message is received
                 _state.executingMission = false;
+                // Will be set to true when an inmediate action is to be received
+                _state.executingStack = false;
 
                 // Initialize MPS parser for serial comms
                 MspParser::init();
@@ -737,6 +741,8 @@ namespace hf {
 
                 // Initialize the planner
                 planner.init(PARAMETER_SLOTS);
+                // and the stack planner
+                individualPlanner.init();
                 // XXX Only for debuging purposes.
                 // planner.printMission();
                 // readEEPROM();

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -696,6 +696,82 @@ namespace hf {
                 _state.armed = false;
                 digitalWrite(25, LOW);
             }
+            
+            // Action handlers
+            virtual void handle_WP_ARM_Request(uint8_t & code) override
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_DISARM_Request(uint8_t & code) override
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_LAND_Request(uint8_t & code) override
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code) override
+            {
+                (void)speed;
+                (void)code;
+            }
+
+            virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code) override
+            {
+                (void)seconds;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code) override
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code) override
+            {
+                (void)degrees;
+                (void)code;
+            }
 
         public:
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -248,11 +248,22 @@ namespace hf {
 
                 // Update ratePid with cyclic demands
                 _ratePid->updateReceiver(_receiver->demands, _receiver->throttleIsDown());
+                
+                // Check if aux1 has changed value. In that case, stop executing 
+                // actions and return control to TX
+                if (_receiver->aux1Changed())
+                {
+                    _state.executingMission = false;
+                    _state.executingStack = false;
+                    planner.reset();
+                    individualPlanner.reset();
+                }
 
                 // Disarm
                 if (  _state.armed && 
                       !_receiver->getAux2State() &&
-                      !_state.executingMission) {
+                      !_state.executingMission &&
+                      !_state.executingStack) {
                     _state.armed = false;
                 }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -155,7 +155,7 @@ namespace hf {
 
                 // Use updated demands to run motors
                 if (_state.armed && !_failsafe && 
-                  (!_receiver->throttleIsDown() || _state.executingStack || _state.executingAction))
+                  (!_receiver->throttleIsDown() || _state.executingStack || _state.executingMission))
                 {
                   _mixer->runArmed(_demands);
                 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -158,7 +158,6 @@ namespace hf {
                   (!_receiver->throttleIsDown() || _state.executingStack || _state.executingAction))
                 {
                   _mixer->runArmed(_demands);
-
                 }
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -154,7 +154,9 @@ namespace hf {
                 runPidControllers();
 
                 // Use updated demands to run motors
-                if (_state.armed && !_failsafe && !_receiver->throttleIsDown()) {
+                if (_state.armed && !_failsafe && 
+                  (!_receiver->throttleIsDown() || _state.executingStack || _state.executingAction))
+                {
                   _mixer->runArmed(_demands);
 
                 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -307,10 +307,19 @@ namespace hf {
                 _sensors[_sensor_count++] = sensor;
             }
 
-            void checkPlanner(void)
+            void checkPlanners(void)
             {
-              if (_state.executingMission == false) return;
-              planner.executeAction(_state, _demands);
+                if (_state.executingStack)
+                {
+                    // turn off mission execution since individual commands have
+                    // a higher priority
+                    _state.executingMission = false;
+                    individualPlanner.executeAction(_state, _demands);
+                }
+                else if (_state.executingMission)
+                {
+                   planner.executeAction(_state, _demands);
+                }
             }
 
             // XXX only for debuging purposes
@@ -700,77 +709,74 @@ namespace hf {
             // Action handlers
             virtual void handle_WP_ARM_Request(uint8_t & code) override
             {
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_ARM, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_DISARM_Request(uint8_t & code) override
             {
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_DISARM, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_LAND_Request(uint8_t & code) override
             {
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_LAND, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_FORWARD, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_BACKWARD, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_LEFT, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_RIGHT, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code) override
-            {
-                (void)speed;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code) override
             {
-                (void)seconds;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_HOVER, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code) override
             {
-                (void)degrees;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CW, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code) override
             {
-                (void)degrees;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CCW, _lastCommandData);
+                _state.executingStack = true;
             }
 
         public:
@@ -860,8 +866,8 @@ namespace hf {
             {
                 // Check Battery
                 checkBattery();
-                // Check planner
-                checkPlanner();
+                // Check planners
+                checkPlanners();
                 // Grab control signal if available
                 checkReceiver();
                 // Check serials for messages

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -39,7 +39,8 @@
 
 #include "filters/eskf.hpp"
 
-#include "planner.hpp"
+//#include "planner.hpp"
+#include "planners/mission.hpp"
 
 namespace hf {
 
@@ -63,7 +64,7 @@ namespace hf {
             Receiver   * _receiver;
             Rate       * _ratePid;
             Mixer      * _mixer;
-            Planner      planner;
+            MissionPlanner      planner;
 
             ESKF eskf = ESKF();
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -98,6 +98,13 @@ namespace hf {
             // Support for headless mode
             float _yawInitial;
 
+            void switchToStackExecution()
+            {
+                _state.executingStack = true;
+                _state.executingMission = false;
+                planner.reset();
+            }
+
             bool safeAngle(uint8_t axis)
             {
                 return fabs(_state.UAVState->eulerAngles[axis]) < _ratePid->maxArmingAngle;
@@ -142,7 +149,6 @@ namespace hf {
                 }
                 lastTime = _board->getTime();
               }
-
 
             }
 
@@ -722,73 +728,73 @@ namespace hf {
             virtual void handle_WP_ARM_Request(uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_ARM, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_DISARM_Request(uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_DISARM, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_LAND_Request(uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_LAND, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_FORWARD, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_BACKWARD, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_LEFT, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_RIGHT, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_HOVER, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CW, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CCW, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
         public:

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -39,7 +39,6 @@
 
 #include "filters/eskf.hpp"
 
-//#include "planner.hpp"
 #include "planners/mission.hpp"
 
 namespace hf {

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -133,13 +133,11 @@ namespace hf {
                   // XXX it might be necessary to trigger the low battery action from here
                   _lowBattery = (_board->getTime() - lastTimeLowBattery > 5);
 
-                  // ---- Provisional
                   if (_lowBattery)
                   {
                     pinMode(25, OUTPUT);
                     digitalWrite(25, LOW);
                   }
-                  // ---- Provisional
 
                   isLastLowBattery = true;
                 }
@@ -329,14 +327,11 @@ namespace hf {
             {
                 if (_state.executingStack)
                 {
-                    // turn off mission execution since individual commands have
-                    // a higher priority
-                    _state.executingMission = false;
                     individualPlanner.executeAction(_state, _demands);
                 }
                 else if (_state.executingMission)
                 {
-                   planner.executeAction(_state, _demands);
+                    planner.executeAction(_state, _demands);
                 }
             }
 
@@ -720,6 +715,7 @@ namespace hf {
                 // as well as stop executing a mission
                 (void)flag;
                 _state.executingMission = false;
+                _state.executingStack = false;
                 _state.armed = false;
                 digitalWrite(25, LOW);
             }

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -40,6 +40,7 @@ namespace hf {
             // Number of EEPROM reserved slots for parameters
             static const int PARAMETER_SLOTS = 150;
             uint8_t MISSION_COMMANDS[13] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+            uint8_t _lastCommandData = 0;
             
         protected:
 
@@ -187,15 +188,23 @@ namespace hf {
 
             void processMissionCommand(uint8_t command)
             {
-                if (incomingMission && isMissionCommand(command))
+                if (isMissionCommand(command))
                 {
-                    EEPROM.write(EEPROMindex, command);
-                    EEPROMindex += 1;
+                    int commandData = -1;
                     if (command != 1 && command != 2 && command != 3)
                     {
-                        uint8_t commandData = readCommandData();
-                        EEPROM.write(EEPROMindex, commandData);
+                        commandData = readCommandData();
+                        _lastCommandData = (uint8_t)commandData;
+                    }
+                    if (incomingMission)
+                    {
+                        EEPROM.write(EEPROMindex, command);
                         EEPROMindex += 1;
+                        if (commandData!=-1)
+                        {
+                          EEPROM.write(EEPROMindex, (uint8_t)commandData);
+                          EEPROMindex += 1;
+                        }
                     }
                 }
             }

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -40,6 +40,10 @@ namespace hf {
             // Number of EEPROM reserved slots for parameters
             static const int PARAMETER_SLOTS = 150;
             uint8_t MISSION_COMMANDS[13] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+            
+        protected:
+
+          bool incomingMission = false;
 
         private:
 
@@ -47,7 +51,6 @@ namespace hf {
             static const int OUTBUF_SIZE = 128;
 
             int EEPROMindex = PARAMETER_SLOTS;
-            bool incomingMission = false;
 
             typedef enum serialState_t {
                 IDLE,

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -48,7 +48,7 @@ namespace hf {
 
               bool setpointIsActive(state_t & state)
               {
-                  return state.executingMission;
+                  return (state.executingMission || state.executingStack);
               }
 
           protected:

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -49,7 +49,7 @@ namespace hf {
             
             void computeReferenceDemands(float _demands[2], state_t &  state, demands_t & demands)
             {
-                if (state.executingMission)
+                if (state.executingMission || state.executingStack)
                 {
                     _demands[0] = demands.setpointAngle[0];
                     _demands[1] = demands.setpointAngle[1];

--- a/src/pidcontrollers/rate.hpp
+++ b/src/pidcontrollers/rate.hpp
@@ -142,7 +142,7 @@ namespace hf {
             {
               _demands[0] = demands.roll;
               _demands[0] = demands.pitch;
-              _demands[2] = state.executingMission ? demands.setpointRate[2] : demands.yaw;
+              _demands[2] = (state.executingMission || state.executingStack) ? demands.setpointRate[2] : demands.yaw;
             }
 
         protected:

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -44,20 +44,6 @@ namespace hf {
             virtual void endOfAction(state_t & state) = 0;
 
         protected:
-            // Set of possible actions
-            static const uint8_t WP_ARM             = 1;
-            static const uint8_t WP_DISARM          = 2;
-            static const uint8_t WP_LAND            = 3;
-            static const uint8_t WP_TAKE_OFF        = 4;
-            static const uint8_t WP_GO_FORWARD      = 5;
-            static const uint8_t WP_GO_BACKWARD     = 6;
-            static const uint8_t WP_GO_LEFT         = 7;
-            static const uint8_t WP_GO_RIGHT        = 8;
-            static const uint8_t WP_CHANGE_ALTITUDE = 9;
-            static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
-            static const uint8_t WP_HOVER           = 11;
-            static const uint8_t WP_TURN_CW         = 12;
-            static const uint8_t WP_TURN_CCW        = 13;
             
             static const uint16_t STACK_LENGTH = 256;
             
@@ -155,6 +141,21 @@ namespace hf {
 
         public:
             
+            // Set of possible actions
+            static const uint8_t WP_ARM             = 1;
+            static const uint8_t WP_DISARM          = 2;
+            static const uint8_t WP_LAND            = 3;
+            static const uint8_t WP_TAKE_OFF        = 4;
+            static const uint8_t WP_GO_FORWARD      = 5;
+            static const uint8_t WP_GO_BACKWARD     = 6;
+            static const uint8_t WP_GO_LEFT         = 7;
+            static const uint8_t WP_GO_RIGHT        = 8;
+            static const uint8_t WP_CHANGE_ALTITUDE = 9;
+            static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
+            static const uint8_t WP_HOVER           = 11;
+            static const uint8_t WP_TURN_CW         = 12;
+            static const uint8_t WP_TURN_CCW        = 13;
+
             void executeAction(state_t & state, demands_t & demands)
             {
                 switch (_currentAction.action) {

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -59,6 +59,8 @@ namespace hf {
             static const uint8_t WP_TURN_CW         = 12;
             static const uint8_t WP_TURN_CCW        = 13;
             
+            static const uint16_t STACK_LENGTH = 256;
+            
             // Required constants and values
             const float DISTANCE_THRESHOLD = 0.2;
             // To achieve desired movement (F/B, L/R and rotations)

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -37,197 +37,42 @@ namespace hf {
 
     } action_t;
 
-
     class Planner {
         
         private:
-          
-          bool _hasMission;
-          
-          // Set of possible actions
-          static const uint8_t WP_ARM             = 1;
-          static const uint8_t WP_DISARM          = 2;
-          static const uint8_t WP_LAND            = 3;
-          static const uint8_t WP_TAKE_OFF        = 4;
-          static const uint8_t WP_GO_FORWARD      = 5;
-          static const uint8_t WP_GO_BACKWARD     = 6;
-          static const uint8_t WP_GO_LEFT         = 7;
-          static const uint8_t WP_GO_RIGHT        = 8;
-          static const uint8_t WP_CHANGE_ALTITUDE = 9;
-          static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
-          static const uint8_t WP_HOVER           = 11;
-          static const uint8_t WP_TURN_CW         = 12;
-          static const uint8_t WP_TURN_CCW        = 13;
-          
-          // Required constants and values
-          const float DISTANCE_THRESHOLD = 0.2;
-          // To achieve desired movement (F/B, L/R and rotations)
-          // XXX Must be tuned
-          const float TARGET_ROLL        = 5;
-          const float TARGET_PITCH       = 5; // angle in degrees
-          const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
-          
-          // Variables used to store the programmed mission
-          action_t _mission[256];
-          uint8_t _currentActionIndex = 0;
-          action_t _currentAction;
-          // mission length
-          uint8_t _missionLength = 0;
-          
-          // for actions that involve time
-          uint32_t _startActionTime = micros();
-          float _startActionYaw;
-          
-          // Each action will be linked to a position with respect to the starting
-          // point. This position marks where the drone should be at the end of
-          // the action and takes in to account the position of the previous action 
-          float _integralPosition[3] = {0, 0, 0};
-                        
-          void loadMission(action_t mission[256], int startingAddress)
-          {
-              int address = startingAddress;
-              int actionIndex = 0;
-              int EEPROMlength = EEPROM.length();
-              // Although we iterate through the whole EEPROM length the index
-              // that tells which address to read is the value of the variable 
-              // address. Some actions, such as hover, have a value (duration 
-              // in this case) linked to them and when this happens we read both
-              // action ( EEPROM index i) and value (EEPROM index i+1) in the
-              // same iteration. We loop through the whole EEPROM length because
-              // it is the maximum number of iterations in the worst case scenario.
-              for (int ii = 0; ii < EEPROMlength; ii++)
-              {
-                // read a byte from the current address of the EEPROM
-                uint8_t value = EEPROM.read(address);
-                // There is no action with code 0, so if a 0 is read we can
-                // safely say that the mission is already loaded and stop reading 
-                if (value == 0 || value == 255) {
-                  break;
-                }
-                int newAddress = addActionToMission(value, mission, actionIndex, address);
-                actionIndex += 1;
-                address = newAddress + 1;
-                // If we reach this point is because at least one instruction
-                // has been loaded
-                _hasMission = true;
-                // update mission length
-                _missionLength += 1;
-              }
-          } // loadMission
-          
-          int addActionToMission(uint8_t value, action_t mission[256],
-                                 int actionIndex, int address)
-          {
-            action_t action = {};
-            switch (value) {
-              
-              case WP_ARM:
-              {
-                  action.action = WP_ARM;
-                  break;
-              }
-              case WP_DISARM:
-              {
-                  action.action = WP_DISARM;
-                  break;
-              }
-              case WP_TAKE_OFF:
-              {
-                  action.action = WP_TAKE_OFF;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  _integralPosition[2] = EEPROM.read(++address);
-                  action.position[2] = _integralPosition[2];
-                  break;
-              }
-              case WP_LAND:
-              {
-                  action.action = WP_LAND;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  action.position[2] = 0;
-                  break;
-              }
-              case WP_CHANGE_ALTITUDE:
-              {
-                  action.action = WP_CHANGE_ALTITUDE;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  _integralPosition[2] = EEPROM.read(++address); 
-                  action.position[2] = _integralPosition[2];
-                  break;
-              }
-              case WP_HOVER:
-              {
-                  action.action = WP_HOVER;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  action.position[2] = _integralPosition[2];
-                  action.duration = EEPROM.read(++address);
-                  break;
-              }
-              case WP_GO_FORWARD: // For the moment, movement is time based
-              {
-                action.action = WP_GO_FORWARD;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;
-              }
-              case WP_GO_BACKWARD:
-              {
-                action.action = WP_GO_BACKWARD;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;                
-              }
-              case WP_GO_LEFT:
-              {
-                action.action = WP_GO_LEFT;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;                
-              }
-              case WP_GO_RIGHT:
-              {
-                action.action = WP_GO_RIGHT;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;                
-              }
-              case WP_TURN_CW:
-              {
-                action.action = WP_TURN_CW;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.rotationDegrees = EEPROM.read(++address);
-                action.clockwise = true;
-                break;                                
-              }
-              case WP_TURN_CCW:
-              {
-                action.action = WP_TURN_CCW;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.rotationDegrees = EEPROM.read(++address);
-                action.clockwise = false;
-                break;                                                
-              }
-            }
-            mission[actionIndex] = action;
-            return address;
-          } // buildAction
+                      
+            virtual void endOfAction(state_t & state) = 0;
 
         protected:
+            // Set of possible actions
+            static const uint8_t WP_ARM             = 1;
+            static const uint8_t WP_DISARM          = 2;
+            static const uint8_t WP_LAND            = 3;
+            static const uint8_t WP_TAKE_OFF        = 4;
+            static const uint8_t WP_GO_FORWARD      = 5;
+            static const uint8_t WP_GO_BACKWARD     = 6;
+            static const uint8_t WP_GO_LEFT         = 7;
+            static const uint8_t WP_GO_RIGHT        = 8;
+            static const uint8_t WP_CHANGE_ALTITUDE = 9;
+            static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
+            static const uint8_t WP_HOVER           = 11;
+            static const uint8_t WP_TURN_CW         = 12;
+            static const uint8_t WP_TURN_CCW        = 13;
+            
+            // Required constants and values
+            const float DISTANCE_THRESHOLD = 0.2;
+            // To achieve desired movement (F/B, L/R and rotations)
+            // XXX Must be tuned
+            const float TARGET_ROLL        = 5;
+            const float TARGET_PITCH       = 5; // angle in degrees
+            const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
+          
+            // for actions that involve time
+            uint32_t _startActionTime = micros();
+            float _startActionYaw;
+
+            uint8_t _currentActionIndex = 0;
+            action_t _currentAction;
 
             bool isActionComplete(action_t action, state_t & state, demands_t & demands)
             {
@@ -307,18 +152,9 @@ namespace hf {
             }
 
         public:
-
-            void init(int startingAddress)
-            {
-                _hasMission = false;
-                loadMission(_mission, startingAddress);
-                _currentActionIndex = 0;
-                _currentAction = _mission[_currentActionIndex];
-            }
             
             void executeAction(state_t & state, demands_t & demands)
             {
-                // XXX Remove prints for oficial release
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
@@ -388,19 +224,6 @@ namespace hf {
                 // and rate targets
                 if (isActionComplete(_currentAction, state, demands))
                 {
-                  // We've reached the end of the mission, reset executing flag
-                  // and return
-                  if (_currentActionIndex == _missionLength - 1)
-                  {
-                      state.executingMission = false;
-                      // Reset action pointer to enable mission execution again
-                      _currentActionIndex = 0;
-                      _currentAction = _mission[0];
-                      return;
-                  }
-                  // Load next action
-                  _currentActionIndex += 1;
-                  _currentAction = _mission[_currentActionIndex];
                   // update starting time and yaw
                   _startActionTime  = micros();
                   _startActionYaw = state.UAVState->eulerAngles[2];
@@ -410,36 +233,12 @@ namespace hf {
                     demands.setpointAngle[i] = 0;
                     demands.setpointRate[i] = 0;
                   }
+                  
+                  // This enables us to define planner specific behaviour that
+                  // gets executed when an action is finished
+                  endOfAction(state);
+                  
                 }
-            }
-
-            // XXX only for debuging purposes
-            void printMission(void)
-            {
-                if (!_hasMission)
-                {
-                    return;
-                }
-                for (int i = 0; i<256; i++)
-                {
-                    action_t action = _mission[i];
-                    Serial.print("Action ");
-                    Serial.println(i);
-                    Serial.print("Action Code: ");
-                    Serial.println(action.action);
-                    Serial.print("Position: ");
-                    Serial.print(action.position[0]);
-                    Serial.print(",");
-                    Serial.print(action.position[1]);
-                    Serial.print(",");
-                    Serial.println(action.position[2]);
-                    Serial.print("Rotation: ");
-                    Serial.println(action.rotationDegrees);
-                    Serial.print("Clockwise: ");
-                    Serial.println(action.clockwise);
-                    Serial.print("Duration: ");
-                    Serial.println(action.duration);
-                } 
             }
 
     };  // class Planner

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -146,7 +146,7 @@
           _stack[_stackIndex] = action;
           _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
           _actionsInStack += 1;
-        } // buildAction
+        } // addActionToStack
 
         virtual void endOfAction(state_t & state) override
         {
@@ -160,7 +160,7 @@
             } else {
                 state.executingStack = false;
             }
-        }
+        } // endOfAction
     
     public:
       

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -90,32 +90,32 @@
             case WP_TAKE_OFF:
             {
                 action.action = WP_TAKE_OFF;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_LAND:
             {
                 action.action = WP_LAND;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = 0;
                 break;
             }
             case WP_CHANGE_ALTITUDE:
             {
                 action.action = WP_CHANGE_ALTITUDE;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_HOVER:
             {
                 action.action = WP_HOVER;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = 0;
                 action.duration = data;
                 break;
@@ -123,8 +123,8 @@
             case WP_GO_FORWARD: // For the moment, movement is time based
             {
               action.action = WP_GO_FORWARD;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;
@@ -132,8 +132,8 @@
             case WP_GO_BACKWARD:
             {
               action.action = WP_GO_BACKWARD;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;                
@@ -141,8 +141,8 @@
             case WP_GO_LEFT:
             {
               action.action = WP_GO_LEFT;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;                
@@ -150,8 +150,8 @@
             case WP_GO_RIGHT:
             {
               action.action = WP_GO_RIGHT;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;                
@@ -159,8 +159,8 @@
             case WP_TURN_CW:
             {
               action.action = WP_TURN_CW;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = true;
@@ -169,8 +169,8 @@
             case WP_TURN_CCW:
             {
               action.action = WP_TURN_CCW;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = false;

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -38,7 +38,7 @@
         // // the action and takes in to account the position of the previous action 
         // float _integralPosition[3] = {0, 0, 0};
 
-        virtual void endOfAction(state_t & state) override
+        virtual void endOfAction(state_t & state, demands_t & demands) override
         {
             _actionsInStack -= 1;
             // Update index from where to grab the next action
@@ -64,6 +64,7 @@
           _currentActionIndex = 0;
           _stackIndex = 0;
           _actionsInStack = 0;
+          _actionStart = true;
         }
         
         void addActionToStack(state_t & state, uint8_t actionCode, int data)
@@ -174,6 +175,7 @@
           _stack[_stackIndex] = action;
           _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
           _actionsInStack += 1;
+          _currentAction = _stack[_currentActionIndex];
         } // addActionToStack
         
       

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -38,6 +38,34 @@
         // // the action and takes in to account the position of the previous action 
         // float _integralPosition[3] = {0, 0, 0};
 
+        virtual void endOfAction(state_t & state) override
+        {
+            _actionsInStack -= 1;
+            // Update index from where to grab the next action
+            _currentActionIndex = (_currentActionIndex + 1) % STACK_LENGTH;
+            // If there are still actions to be performed load the next one
+            if (_actionsInStack > 0)
+            {
+                _currentAction = _stack[_currentActionIndex];
+            } else {
+                state.executingStack = false;
+            }
+        } // endOfAction
+    
+    public:
+      
+        void init()
+        {
+            reset();
+        }
+
+        void reset()
+        {
+          _currentActionIndex = 0;
+          _stackIndex = 0;
+          _actionsInStack = 0;
+        }
+        
         void addActionToStack(state_t & state, uint8_t actionCode, int data)
         {
           action_t action = {};
@@ -147,34 +175,7 @@
           _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
           _actionsInStack += 1;
         } // addActionToStack
-
-        virtual void endOfAction(state_t & state) override
-        {
-            _actionsInStack -= 1;
-            // Update index from where to grab the next action
-            _currentActionIndex = (_currentActionIndex + 1) % STACK_LENGTH;
-            // If there are still actions to be performed load the next one
-            if (_actionsInStack > 0)
-            {
-                _currentAction = _stack[_currentActionIndex];
-            } else {
-                state.executingStack = false;
-            }
-        } // endOfAction
-    
-    public:
-      
-        void init()
-        {
-            reset();
-        }
-
-        void reset()
-        {
-          _currentActionIndex = 0;
-          _stackIndex = 0;
-          _actionsInStack = 0;
-        }
+        
       
     }; // class IndividualPlanner
 

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -47,6 +47,11 @@
             if (_actionsInStack > 0)
             {
                 _currentAction = _stack[_currentActionIndex];
+                // Set target height as the end height of the previous action
+                // except for land action
+                _currentAction.position[2] = _currentAction.position[2] == 0 ? state.UAVState->position[0] : _currentAction.position[2];
+                if (_currentAction.action == WP_LAND) _currentAction.position[2] = 0;
+                
             } else {
                 state.executingStack = false;
             }
@@ -85,78 +90,78 @@
             case WP_TAKE_OFF:
             {
                 action.action = WP_TAKE_OFF;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
+                action.position[0] = 0;
+                action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_LAND:
             {
                 action.action = WP_LAND;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
+                action.position[0] = 0;
+                action.position[1] = 0;
                 action.position[2] = 0;
                 break;
             }
             case WP_CHANGE_ALTITUDE:
             {
                 action.action = WP_CHANGE_ALTITUDE;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
+                action.position[0] = 0;
+                action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_HOVER:
             {
                 action.action = WP_HOVER;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
-                action.position[2] = state.UAVState->position[2];
+                action.position[0] = 0;
+                action.position[1] = 0;
+                action.position[2] = 0;
                 action.duration = data;
                 break;
             }
             case WP_GO_FORWARD: // For the moment, movement is time based
             {
               action.action = WP_GO_FORWARD;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;
             }
             case WP_GO_BACKWARD:
             {
               action.action = WP_GO_BACKWARD;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;                
             }
             case WP_GO_LEFT:
             {
               action.action = WP_GO_LEFT;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;                
             }
             case WP_GO_RIGHT:
             {
               action.action = WP_GO_RIGHT;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;                
             }
             case WP_TURN_CW:
             {
               action.action = WP_TURN_CW;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = true;
               break;                                
@@ -164,9 +169,9 @@
             case WP_TURN_CCW:
             {
               action.action = WP_TURN_CCW;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = false;
               break;                                                

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -1,0 +1,181 @@
+/*
+   stack.hpp : Stack planner class that enables inmediate action execution
+
+   Copyright (c) 2018 Juan Gallostra
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #pragma once
+ 
+ #include "planner.hpp"
+ 
+ namespace hf {
+ 
+    class IndividualPlanner : public Planner {
+      
+    private:
+
+        // Variables used to store the actions to be executed
+        action_t _stack[STACK_LENGTH];
+        // stack length
+        uint8_t _actionsInStack = 0; // Number of actions
+        uint8_t _stackIndex = 0;  // Where to add the next action
+        // // Each action will be linked to a position with respect to the starting
+        // // point. This position marks where the drone should be at the end of
+        // // the action and takes in to account the position of the previous action 
+        // float _integralPosition[3] = {0, 0, 0};
+
+        void addActionToStack(state_t & state, uint8_t actionCode, int data)
+        {
+          action_t action = {};
+          switch (actionCode) {
+            
+            case WP_ARM:
+            {
+                action.action = WP_ARM;
+                break;
+            }
+            case WP_DISARM:
+            {
+                action.action = WP_DISARM;
+                break;
+            }
+            case WP_TAKE_OFF:
+            {
+                action.action = WP_TAKE_OFF;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = data;
+                break;
+            }
+            case WP_LAND:
+            {
+                action.action = WP_LAND;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = 0;
+                break;
+            }
+            case WP_CHANGE_ALTITUDE:
+            {
+                action.action = WP_CHANGE_ALTITUDE;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = data;
+                break;
+            }
+            case WP_HOVER:
+            {
+                action.action = WP_HOVER;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = state.UAVState->position[2];
+                action.duration = data;
+                break;
+            }
+            case WP_GO_FORWARD: // For the moment, movement is time based
+            {
+              action.action = WP_GO_FORWARD;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;
+            }
+            case WP_GO_BACKWARD:
+            {
+              action.action = WP_GO_BACKWARD;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;                
+            }
+            case WP_GO_LEFT:
+            {
+              action.action = WP_GO_LEFT;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;                
+            }
+            case WP_GO_RIGHT:
+            {
+              action.action = WP_GO_RIGHT;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;                
+            }
+            case WP_TURN_CW:
+            {
+              action.action = WP_TURN_CW;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.rotationDegrees = data;
+              action.clockwise = true;
+              break;                                
+            }
+            case WP_TURN_CCW:
+            {
+              action.action = WP_TURN_CCW;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.rotationDegrees = data;
+              action.clockwise = false;
+              break;                                                
+            }
+          }
+          _stack[_stackIndex] = action;
+          _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
+          _actionsInStack += 1;
+        } // buildAction
+
+        virtual void endOfAction(state_t & state) override
+        {
+            _actionsInStack -= 1;
+            // Update index from where to grab the next action
+            _currentActionIndex = (_currentActionIndex + 1) % STACK_LENGTH;
+            // If there are still actions to be performed load the next one
+            if (_actionsInStack > 0)
+            {
+                _currentAction = _stack[_currentActionIndex];
+            } else {
+                state.executingStack = false;
+            }
+        }
+    
+    public:
+      
+        void init()
+        {
+            reset();
+        }
+
+        void reset()
+        {
+          _currentActionIndex = 0;
+          _stackIndex = 0;
+          _actionsInStack = 0;
+        }
+      
+    }; // class IndividualPlanner
+
+} // namespace hf

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -206,8 +206,13 @@
         {
               _hasMission = false;
               loadMission(_mission, startingAddress);
-              _currentActionIndex = 0;
-              _currentAction = _mission[_currentActionIndex];
+              reset();
+        }
+        
+        void reset()
+        {
+          _currentActionIndex = 0;
+          _currentAction = _mission[_currentActionIndex];
         }
         
         // XXX only for debuging purposes

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -1,0 +1,243 @@
+/*
+   mission.hpp : Flight mission planner class
+
+   Copyright (c) 2018 Juan Gallostra
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #pragma once
+ 
+ #include <EEPROM.h>
+ #include "planner.hpp"
+ 
+ namespace hf {
+ 
+    class MissionPlanner : public Planner {
+      
+    private:
+
+        bool _hasMission;
+        // Variables used to store the programmed mission
+        action_t _mission[256];
+        // mission length
+        uint8_t _missionLength = 0;
+        // Each action will be linked to a position with respect to the starting
+        // point. This position marks where the drone should be at the end of
+        // the action and takes in to account the position of the previous action 
+        float _integralPosition[3] = {0, 0, 0};
+
+        void loadMission(action_t mission[256], int startingAddress)
+        {
+            int address = startingAddress;
+            int actionIndex = 0;
+            int EEPROMlength = EEPROM.length();
+            // Although we iterate through the whole EEPROM length the index
+            // that tells which address to read is the value of the variable 
+            // address. Some actions, such as hover, have a value (duration 
+            // in this case) linked to them and when this happens we read both
+            // action ( EEPROM index i) and value (EEPROM index i+1) in the
+            // same iteration. We loop through the whole EEPROM length because
+            // it is the maximum number of iterations in the worst case scenario.
+            for (int ii = 0; ii < EEPROMlength; ii++)
+            {
+              // read a byte from the current address of the EEPROM
+              uint8_t value = EEPROM.read(address);
+              // There is no action with code 0, so if a 0 is read we can
+              // safely say that the mission is already loaded and stop reading 
+              if (value == 0 || value == 255) {
+                break;
+              }
+              int newAddress = addActionToMission(value, mission, actionIndex, address);
+              actionIndex += 1;
+              address = newAddress + 1;
+              // If we reach this point is because at least one instruction
+              // has been loaded
+              _hasMission = true;
+              // update mission length
+              _missionLength += 1;
+            }
+        } // loadMission
+        
+        int addActionToMission(uint8_t value, action_t mission[256],
+                               int actionIndex, int address)
+        {
+          action_t action = {};
+          switch (value) {
+            
+            case WP_ARM:
+            {
+                action.action = WP_ARM;
+                break;
+            }
+            case WP_DISARM:
+            {
+                action.action = WP_DISARM;
+                break;
+            }
+            case WP_TAKE_OFF:
+            {
+                action.action = WP_TAKE_OFF;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                _integralPosition[2] = EEPROM.read(++address);
+                action.position[2] = _integralPosition[2];
+                break;
+            }
+            case WP_LAND:
+            {
+                action.action = WP_LAND;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = 0;
+                break;
+            }
+            case WP_CHANGE_ALTITUDE:
+            {
+                action.action = WP_CHANGE_ALTITUDE;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                _integralPosition[2] = EEPROM.read(++address); 
+                action.position[2] = _integralPosition[2];
+                break;
+            }
+            case WP_HOVER:
+            {
+                action.action = WP_HOVER;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.duration = EEPROM.read(++address);
+                break;
+            }
+            case WP_GO_FORWARD: // For the moment, movement is time based
+            {
+              action.action = WP_GO_FORWARD;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;
+            }
+            case WP_GO_BACKWARD:
+            {
+              action.action = WP_GO_BACKWARD;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;                
+            }
+            case WP_GO_LEFT:
+            {
+              action.action = WP_GO_LEFT;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;                
+            }
+            case WP_GO_RIGHT:
+            {
+              action.action = WP_GO_RIGHT;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;                
+            }
+            case WP_TURN_CW:
+            {
+              action.action = WP_TURN_CW;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.rotationDegrees = EEPROM.read(++address);
+              action.clockwise = true;
+              break;                                
+            }
+            case WP_TURN_CCW:
+            {
+              action.action = WP_TURN_CCW;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.rotationDegrees = EEPROM.read(++address);
+              action.clockwise = false;
+              break;                                                
+            }
+          }
+          mission[actionIndex] = action;
+          return address;
+        } // buildAction
+
+        virtual void endOfAction(state_t & state) override
+        {
+          // Load next action
+          _currentActionIndex += 1;
+          _currentAction = _mission[_currentActionIndex];
+          // We've reached the end of the mission, reset executing flag
+          // and return
+          if (_currentActionIndex == _missionLength - 1)
+          {
+              state.executingMission = false;
+              // Reset action pointer to enable mission execution again
+              _currentActionIndex = 0;
+              _currentAction = _mission[0];
+          }
+        }
+    
+    public:
+      
+        void init(int startingAddress)
+        {
+              _hasMission = false;
+              loadMission(_mission, startingAddress);
+              _currentActionIndex = 0;
+              _currentAction = _mission[_currentActionIndex];
+        }
+        
+        // XXX only for debuging purposes
+        void printMission(void)
+        {
+            if (!_hasMission)
+            {
+                return;
+            }
+            for (int i = 0; i<256; i++)
+            {
+                action_t action = _mission[i];
+                Serial.print("Action ");
+                Serial.println(i);
+                Serial.print("Action Code: ");
+                Serial.println(action.action);
+                Serial.print("Position: ");
+                Serial.print(action.position[0]);
+                Serial.print(",");
+                Serial.print(action.position[1]);
+                Serial.print(",");
+                Serial.println(action.position[2]);
+                Serial.print("Rotation: ");
+                Serial.println(action.rotationDegrees);
+                Serial.print("Clockwise: ");
+                Serial.println(action.clockwise);
+                Serial.print("Duration: ");
+                Serial.println(action.duration);
+            } 
+        }      
+      
+    }; // class Mission
+ 
+} // namespace hf

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -183,12 +183,13 @@
           return address;
         } // buildAction
 
-        virtual void endOfAction(state_t & state) override
+        virtual void endOfAction(state_t & state, demands_t & demands) override
         {
           // Load next action
           _currentActionIndex += 1;
           _currentAction = _mission[_currentActionIndex];
-          // We've reached the end of the mission, reset executing flag
+          _startActionYaw = state.UAVState->eulerAngles[2];
+          // If we have reached the end of the mission, reset executing flag
           // and return
           if (_currentActionIndex == _missionLength - 1)
           {

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -31,7 +31,7 @@
 
         bool _hasMission;
         // Variables used to store the programmed mission
-        action_t _mission[256];
+        action_t _mission[STACK_LENGTH];
         // mission length
         uint8_t _missionLength = 0;
         // Each action will be linked to a position with respect to the starting
@@ -39,7 +39,7 @@
         // the action and takes in to account the position of the previous action 
         float _integralPosition[3] = {0, 0, 0};
 
-        void loadMission(action_t mission[256], int startingAddress)
+        void loadMission(action_t mission[STACK_LENGTH], int startingAddress)
         {
             int address = startingAddress;
             int actionIndex = 0;
@@ -71,7 +71,7 @@
             }
         } // loadMission
         
-        int addActionToMission(uint8_t value, action_t mission[256],
+        int addActionToMission(uint8_t value, action_t mission[STACK_LENGTH],
                                int actionIndex, int address)
         {
           action_t action = {};
@@ -216,7 +216,7 @@
             {
                 return;
             }
-            for (int i = 0; i<256; i++)
+            for (int i = 0; i<STACK_LENGTH; i++)
             {
                 action_t action = _mission[i];
                 Serial.print("Action ");

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -90,8 +90,8 @@
             case WP_TAKE_OFF:
             {
                 action.action = WP_TAKE_OFF;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 _integralPosition[2] = EEPROM.read(++address);
                 action.position[2] = _integralPosition[2];
                 break;
@@ -99,16 +99,16 @@
             case WP_LAND:
             {
                 action.action = WP_LAND;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 action.position[2] = 0;
                 break;
             }
             case WP_CHANGE_ALTITUDE:
             {
                 action.action = WP_CHANGE_ALTITUDE;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 _integralPosition[2] = EEPROM.read(++address); 
                 action.position[2] = _integralPosition[2];
                 break;
@@ -116,8 +116,8 @@
             case WP_HOVER:
             {
                 action.action = WP_HOVER;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 action.position[2] = _integralPosition[2];
                 action.duration = EEPROM.read(++address);
                 break;
@@ -125,8 +125,8 @@
             case WP_GO_FORWARD: // For the moment, movement is time based
             {
               action.action = WP_GO_FORWARD;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;
@@ -134,8 +134,8 @@
             case WP_GO_BACKWARD:
             {
               action.action = WP_GO_BACKWARD;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;                
@@ -143,8 +143,8 @@
             case WP_GO_LEFT:
             {
               action.action = WP_GO_LEFT;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;                
@@ -152,8 +152,8 @@
             case WP_GO_RIGHT:
             {
               action.action = WP_GO_RIGHT;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;                
@@ -161,8 +161,8 @@
             case WP_TURN_CW:
             {
               action.action = WP_TURN_CW;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.rotationDegrees = EEPROM.read(++address);
               action.clockwise = true;
@@ -171,8 +171,8 @@
             case WP_TURN_CCW:
             {
               action.action = WP_TURN_CCW;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.rotationDegrees = EEPROM.read(++address);
               action.clockwise = false;

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -116,6 +116,7 @@ namespace hf {
         // maximum number of channels that any receiver will send (of which we'll use six)
         static const uint8_t MAXCHAN = 8;
 
+        uint8_t _lastAux1State;
         uint8_t _aux1State;
         uint8_t _aux2State;
 
@@ -239,6 +240,7 @@ namespace hf {
             demands.throttle = throttleFun(rawvals[_channelMap[CHANNEL_THROTTLE]]);
             
             // Store auxiliary switch state
+            _lastAux1State = _aux1State;
             _aux1State = getRawval(CHANNEL_AUX1) >= 0.0 ? (getRawval(CHANNEL_AUX1) > .4 ? 2 : 1) : 0;
             _aux2State = getRawval(CHANNEL_AUX2) >= 0.4 ? 1 : 0;
 
@@ -292,6 +294,11 @@ namespace hf {
         void setCalibrationStatus(bool calibrated)
         {
             _calibrated = calibrated;
+        }
+        
+        bool aux1Changed()
+        {
+           return (_lastAux1State != _aux1State);
         }
         
         virtual void pollForFrame(void) {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issues: #114 #115  

1. Enable the Mosquito to execute any of the defined actions (arm, takeoff, hover, land, etc.) immediately when requested via MSP.

2. When executing a flight mission, switching the value of the `aux 1 ` in the remote returns the control of the drone to the TX or APP.

## Current behavior before PR

Actions can only be executed in the context of a flight mission and when executing a flight mission control of the drone is not recovered until the mission ends.

## Desired behavior after PR is merged

1. Actions can be executed individually and outside the context of a flight mission.
2. When executing a flight mission control of the drone can be recovered via the `aux 1` switch
