### PR TITLE
Land when low battery is detected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 * #116 Enable immediate execution of actions
 * #116 When executing a flight mission, switching the value of the aux 1 in the remote returns the control of the drone to the TX or APP
 * #117 Flight missions planner
+* #118 Land when low battery is detected
 
 ### Changed
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -55,6 +55,7 @@ namespace hf {
             virtual bool  getQuaternion(float quat[4]) = 0;
             virtual void  writeMotor(uint8_t index, float value) = 0;
             virtual float getTime(void) = 0;
+            virtual float getLowBatteryLimit(void) = 0;
 
             //------------------------- Support for additional surface-mount sensors -------------------------------------
             virtual bool  getGyrometer(float gyroRates[3]) { (void)gyroRates;  return false; }
@@ -74,7 +75,6 @@ namespace hf {
             //----------------------------------------- Safety -----------------------------------------------------------
             virtual void showArmedStatus(bool armed) { (void)armed; }
             virtual void flashLed(bool shouldflash) { (void)shouldflash; }
-            virtual bool isBatteryLow(void) { return false; }
 
             //--------------------------------------- Debugging ----------------------------------------------------------
             static void  outbuf(char * buf);

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -184,6 +184,7 @@ namespace hf {
             // Min, max PWM values
             const uint16_t PWM_MIN = 100;
             const uint16_t PWM_MAX = 500;
+            const float _lowBattery = 10.8;
 
         protected:
             
@@ -206,10 +207,19 @@ namespace hf {
                     analogWrite(MOTOR_PINS[k], PWM_MIN);
                 }
             }
+            
+            virtual float getLowBatteryLimit(void) override
+            {
+                return _lowBattery;
+            }
 
     }; // class BonadroneMultiShot
 
     class BonadroneBrushed : public Bonadrone {
+
+        private:
+          
+          const float _lowBattery = 3.3;
 
         protected:
 
@@ -230,6 +240,12 @@ namespace hf {
                 analogWrite(MOTOR_PINS[k], 0);  
             }
         }
+        
+        virtual float getLowBatteryLimit(void) override
+        {
+          return _lowBattery;
+        }
+
 
     }; // class BonadroneBrushed
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -92,9 +92,6 @@ namespace hf {
             bool _failsafe;
             bool _lowBattery;
 
-            // XXX Store it as an MSP parameter
-            const float _BAT_MIN = 3.3; // Minimum voltage for 1S Battery
-
             // Support for headless mode
             float _yawInitial;
 
@@ -124,7 +121,7 @@ namespace hf {
               if (_board->getTime() - lastTime > 0.5)
               {
                 // Look if the battery is below the limit
-                if (_state.batteryVoltage < _BAT_MIN && _state.batteryVoltage > 2.5)
+                if (_state.batteryVoltage < _board->getLowBatteryLimit() && _state.batteryVoltage > 2.5)
                 {
                   // Save the first time it detects low battery
                   lastTimeLowBattery = ((isLastLowBattery) ? lastTimeLowBattery:_board->getTime());
@@ -137,6 +134,9 @@ namespace hf {
                   {
                     pinMode(25, OUTPUT);
                     digitalWrite(25, LOW);
+                    // XXX Ring the buzzer 
+                    individualPlanner.addActionToStack(_state, individualPlanner.WP_LAND, 0);
+                    switchToStackExecution();
                   }
 
                   isLastLowBattery = true;
@@ -233,14 +233,14 @@ namespace hf {
             void checkFailsafe(void)
             {
                 if (_state.armed &&
-                   (_receiver->lostSignal(_receiver->getBypassReceiver()) || _board->isBatteryLow())) {
+                   (_receiver->lostSignal(_receiver->getBypassReceiver()))) {
                     _mixer->cutMotors();
                     _state.armed = false;
                     _failsafe = true;
                     _board->showArmedStatus(false);
                     if (_receiver->getLostSignal())
                     {
-                      _receiver->setBypassReceiver(false);
+                        _receiver->setBypassReceiver(false);
                     }
                 }
             }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issues: #74 #63 

When Low battery is detected the drone lands.

## Current behavior before PR

When low battery is detected the red LED is turned on but no action is performed.

## Desired behavior after PR is merged

When Low battery is detected the drone lands.