### PR TITLE
Limit instructions max height

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 * #107 Increase main loop speed
 * #111 Correct only with one sensor when calling the main loop ESKF correct function.
 * #119 Arming checks
+* #120 Limit maximum height when executing a mission
 
 ### Removed
 

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -54,6 +54,8 @@ namespace hf {
             const float TARGET_ROLL        = 5;
             const float TARGET_PITCH       = 5; // angle in degrees
             const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
+            
+            const float MAX_HEIGHT         = 3;
           
             // for actions that involve time
             bool _actionStart = true;
@@ -164,6 +166,9 @@ namespace hf {
                     _actionStart = false; 
                     _startActionTime = micros();
                     _startActionYaw = state.UAVState->eulerAngles[2];
+                    // Limit maximum height of the actions
+                    if (_currentAction.position[2] > MAX_HEIGHT)
+                        _currentAction.position[2] = MAX_HEIGHT;
                 } 
                 switch (_currentAction.action) {
                   case WP_ARM:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #85  

For safety reasons, limit the maximum height the Mosquito can fly at while executing a mission. This maximum height has been set to 3m.

## Current behavior before PR

There wasn't any limitation in the height the drone could fly at.

## Desired behavior after PR is merged

The drone does not fly above 3m, even if requested, when executing a flight mission.
