### PR TITLE
Planner integration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 * #105 Filter ESKF estimated linear velocities with a LPF
 * #116 Enable immediate execution of actions
 * #116 When executing a flight mission, switching the value of the aux 1 in the remote returns the control of the drone to the TX or APP
+* #117 Flight missions planner
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 * #104 Vertical velocity control when in Altitude Hold mode and outside of the deadband 
 * #105 Filter ESKF estimated linear velocities with a LPF
 * #116 Enable immediate execution of actions
+* #116 When executing a flight mission, switching the value of the aux 1 in the remote returns the control of the drone to the TX or APP
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 * #103 Allow to define MSP messages with ID > 200 that do not acknowledge
 * #104 Vertical velocity control when in Altitude Hold mode and outside of the deadband 
 * #105 Filter ESKF estimated linear velocities with a LPF
+* #116 Enable immediate execution of actions
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 * #107 Increase main loop speed
 * #111 Correct only with one sensor when calling the main loop ESKF correct function.
 * #119 Arming checks
+* #120 Limit maximum height when executing a mission
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@
 * #80 Enable clearing EEPROM by sections
 * #107 Increase main loop speed
 * #111 Correct only with one sensor when calling the main loop ESKF correct function.
+* #119 Arming checks
 
 ### Removed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 * #116 Enable immediate execution of actions
 * #116 When executing a flight mission, switching the value of the aux 1 in the remote returns the control of the drone to the TX or APP
 * #117 Flight missions planner
+* #118 Land when low battery is detected
 
 ### Changed
 

--- a/extras/parser/messages.json
+++ b/extras/parser/messages.json
@@ -11,6 +11,12 @@
    {"magy": "short"},
    {"magz": "short"}],
 
+  "GET_VELOCITIES":
+  [{"ID": 103},
+   {"velx": "float"},
+   {"vely": "float"},
+   {"velz": "float"}],
+
   "RC_NORMAL":
   [{"ID": 121},
    {"comment": "16 channels in http://www.multiwii.com/wiki/index.php?title=Multiwii_Serial_Protocol"},

--- a/extras/parser/resources/mspparser.hpp
+++ b/extras/parser/resources/mspparser.hpp
@@ -39,6 +39,7 @@ namespace hf {
             
             // Number of EEPROM reserved slots for parameters
             static const int PARAMETER_SLOTS = 150;
+            uint8_t MISSION_COMMANDS[13] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
 
         private:
 
@@ -183,7 +184,7 @@ namespace hf {
 
             void processMissionCommand(uint8_t command)
             {
-                if (incomingMission && command != 23)
+                if (incomingMission && isMissionCommand(command))
                 {
                     EEPROM.write(EEPROMindex, command);
                     EEPROMindex += 1;
@@ -199,6 +200,15 @@ namespace hf {
             uint8_t readCommandData(void)
             {
                 return _inBuf[_inBufIndex++] & 0xff;
+            }
+
+            bool isMissionCommand(uint8_t command)
+            {
+                for(int i=0; i<sizeof(MISSION_COMMANDS)/sizeof(MISSION_COMMANDS[0]); ++i)
+                {
+                    if (command == MISSION_COMMANDS[i]) return true;
+                }
+                return false;
             }
 
         protected:

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -55,6 +55,7 @@ namespace hf {
             virtual bool  getQuaternion(float quat[4]) = 0;
             virtual void  writeMotor(uint8_t index, float value) = 0;
             virtual float getTime(void) = 0;
+            virtual float getLowBatteryLimit(void) = 0;
 
             //------------------------- Support for additional surface-mount sensors -------------------------------------
             virtual bool  getGyrometer(float gyroRates[3]) { (void)gyroRates;  return false; }
@@ -74,7 +75,6 @@ namespace hf {
             //----------------------------------------- Safety -----------------------------------------------------------
             virtual void showArmedStatus(bool armed) { (void)armed; }
             virtual void flashLed(bool shouldflash) { (void)shouldflash; }
-            virtual bool isBatteryLow(void) { return false; }
 
             //--------------------------------------- Debugging ----------------------------------------------------------
             static void  outbuf(char * buf);

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -58,7 +58,6 @@ namespace hf {
 
             //------------------------------------ Core functionality ----------------------------------------------------
             virtual bool  getIMU(float gyroRates[3], float accels[3]) = 0;
-            virtual bool  getQuaternion(float quat[4]) = 0;
             virtual void  writeMotor(uint8_t index, float value) = 0;
             virtual float getTime(void) = 0;
             virtual float getLowBatteryLimit(void) = 0;
@@ -68,6 +67,7 @@ namespace hf {
             virtual bool  getAccelerometer(float accelGs[3]) { (void)accelGs;  return false; }
             virtual bool  getMagnetometer(float uTs[3]) { (void)uTs;  return false; }
             virtual bool  getBarometer(float & pressure) { (void)pressure;  return false; }
+            virtual bool  getQuaternion(float quat[4]) { (void)quat;  return false; }
 
             //------------------------------- Serial communications via MSP ----------------------------------------------
             virtual void    setSerialFlag(void) = 0;

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -39,15 +39,21 @@ namespace hf {
         protected:
 
             // NB: gyrometer, accelerometer should return values as follows,
-            // based on the Ladybug Flight Controller:
+            // based on the BonaDrone Flight Controller:
+            //
+            // IMU Axis are:
+            //
+            //     ^
+            //     |x
+            // y <-·z
             //
             // AX: pitch forward +, back -
-            // AY: roll right +,    left -
-            // AZ: rightside-up +,  upside-down -
+            // AY: roll right -,    left +
+            // AZ: rightside-up -,  upside-down +
             //
             // GX: roll right +,    left -
-            // GY: pitch forward -, back +
-            // GZ: yaw left -,      right +
+            // GY: pitch forward +, back -
+            // GZ: yaw left +,      right -
 
 
             //------------------------------------ Core functionality ----------------------------------------------------

--- a/src/boards/bonadrone.hpp
+++ b/src/boards/bonadrone.hpp
@@ -184,6 +184,7 @@ namespace hf {
             // Min, max PWM values
             const uint16_t PWM_MIN = 100;
             const uint16_t PWM_MAX = 500;
+            const float _lowBattery = 10.8;
 
         protected:
             
@@ -206,10 +207,19 @@ namespace hf {
                     analogWrite(MOTOR_PINS[k], PWM_MIN);
                 }
             }
+            
+            virtual float getLowBatteryLimit(void) override
+            {
+                return _lowBattery;
+            }
 
     }; // class BonadroneMultiShot
 
     class BonadroneBrushed : public Bonadrone {
+
+        private:
+          
+          const float _lowBattery = 3.3;
 
         protected:
 
@@ -230,6 +240,12 @@ namespace hf {
                 analogWrite(MOTOR_PINS[k], 0);  
             }
         }
+        
+        virtual float getLowBatteryLimit(void) override
+        {
+          return _lowBattery;
+        }
+
 
     }; // class BonadroneBrushed
 

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -29,8 +29,7 @@ typedef struct {
     float roll;
     float pitch;
     float yaw;
-    float altitude;
-
+    float setpoint[3];            // X, Y, Z setpoint
 } demands_t;
 
 typedef struct {
@@ -38,7 +37,6 @@ typedef struct {
     bool  armed;
     bool  executingMission;
     float batteryVoltage;         // current Voltage
-    float setpoint[3];            // X, Y, Z setpoint
 } state_t;
 
 typedef struct {

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -34,7 +34,7 @@ typedef struct {
 } demands_t;
 
 typedef struct {
-    hf::eskf_state_t * UAVState;  // Mosquito status 
+    hf::eskf_state_t * UAVState;  // Mosquito spatial state 
     bool  armed;
     bool  executingMission = false;
     bool  executingStack = false;

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -34,11 +34,11 @@ typedef struct {
 } demands_t;
 
 typedef struct {
-    hf::eskf_state_t * UAVState;
+    hf::eskf_state_t * UAVState;  // Mosquito status 
     bool  armed;
     bool  executingMission;
-    float batteryVoltage; 
-
+    float batteryVoltage;         // current Voltage
+    float setpoint[3];            // X, Y, Z setpoint
 } state_t;
 
 typedef struct {

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -38,6 +38,7 @@ typedef struct {
     hf::eskf_state_t * UAVState;  // Mosquito status 
     bool  armed;
     bool  executingMission;
+    bool  executingStack;
     float batteryVoltage;         // current Voltage
 } state_t;
 

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -28,9 +28,9 @@ typedef struct {
     float roll;
     float pitch;
     float yaw;
-    float setpoint[3];            // X, Y, Z setpoint
-    float setpointAngle[3];       // Roll, pitch, yaw, setpoint
-    float setpointRate[3];        // Roll, pitch, yaw, setpoint
+    float setpoint[3] = {0,0,0};            // X, Y, Z setpoint
+    float setpointAngle[3] = {0,0,0};       // Roll, pitch, yaw, setpoint
+    float setpointRate[3] = {0,0,0};        // Roll, pitch, yaw, setpoint
 } demands_t;
 
 typedef struct {

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -30,6 +30,7 @@ typedef struct {
     float pitch;
     float yaw;
     float setpoint[3];            // X, Y, Z setpoint
+    float setpointAngle[3];       // Roll, pitch, yaw, setpoint
 } demands_t;
 
 typedef struct {

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -38,6 +38,7 @@ typedef struct {
     bool  armed;
     bool  executingMission = false;
     bool  executingStack = false;
+    bool  takingOff = false;
     float batteryVoltage;         // current Voltage
 } state_t;
 

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -24,14 +24,13 @@
 #include "filters/eskf_struct.hpp"
 
 typedef struct {
-
-    float throttle;
+    float throttle;               // T, R, P and Y come from receiver
     float roll;
     float pitch;
     float yaw;
     float setpoint[3];            // X, Y, Z setpoint
     float setpointAngle[3];       // Roll, pitch, yaw, setpoint
-    float setpointRate[3];       // Roll, pitch, yaw, setpoint
+    float setpointRate[3];        // Roll, pitch, yaw, setpoint
 } demands_t;
 
 typedef struct {

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -51,3 +51,10 @@ typedef struct {
     float _max[4] = {0, 0, 0, 0};   // T, R, P, Y
 } tx_calibration_t;
 
+typedef enum {
+  RATE,
+  LEVEL,
+  ALTHOLD,
+  POSHOLD
+} ControllerType_t;
+

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -38,7 +38,6 @@ typedef struct {
     bool  armed;
     bool  executingMission = false;
     bool  executingStack = false;
-    bool  takingOff = false;
     float batteryVoltage;         // current Voltage
 } state_t;
 

--- a/src/datatypes.hpp
+++ b/src/datatypes.hpp
@@ -31,6 +31,7 @@ typedef struct {
     float yaw;
     float setpoint[3];            // X, Y, Z setpoint
     float setpointAngle[3];       // Roll, pitch, yaw, setpoint
+    float setpointRate[3];       // Roll, pitch, yaw, setpoint
 } demands_t;
 
 typedef struct {

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -407,6 +407,17 @@ namespace hf {
                 yaw   = _state.UAVState->eulerAngles[2];
             }
 
+            virtual void handle_GET_VELOCITIES_Request(float & velx, float & vely, float & velz) override
+            {
+                // XXX For debugging, only send vels while on poshold
+                if (_receiver->getAux1State())
+                {
+                  velx = _state.UAVState->linearVelocities[0];
+                  vely = _state.UAVState->linearVelocities[1];
+                  velz = _state.UAVState->linearVelocities[2];
+                }
+            }
+
             virtual void handle_SET_MOTOR_NORMAL_Request(float  m1, float  m2, float  m3, float  m4) override
             {
                 _mixer->motorsDisarmed[0] = m1;

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -850,7 +850,7 @@ namespace hf {
                 // XXX Ideal behavior: add sensors and ensure a method (not harcoded)
                 // XXX that adds ESKF sensors depending on how they have been added in the sensors array.
 
-                // Error state kalman filter
+                // Error state kalman filter initialization
                 eskf.init();
                 eskf.addSensorESKF(&_imu);
                 eskf.addSensorESKF(&_accelerometer);
@@ -921,7 +921,6 @@ namespace hf {
 
             void update(void)
             { 
-                
                 // Check Battery
                 checkBattery();
                 // Check planners
@@ -930,7 +929,6 @@ namespace hf {
                 checkReceiver();
                 // Check serials for messages
                 doSerialComms();
-
                 // Estimate and correct states via the ESKF
                 updateStateEstimate();
                 correctStateEstimate();

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -359,11 +359,11 @@ namespace hf {
             {
                 if (_state.executingStack)
                 {
-                    individualPlanner.executeAction(_state, _demands, safeToArm());
+                    individualPlanner.executeAction(_state, _demands, safeToArm(), _pid_controllers, _pid_controller_count);
                 }
                 else if (_state.executingMission)
                 {
-                    planner.executeAction(_state, _demands, safeToArm());
+                    planner.executeAction(_state, _demands, safeToArm(), _pid_controllers, _pid_controller_count);
                 }
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -278,9 +278,11 @@ namespace hf {
                         !_state.armed &&
                         _receiver->throttleIsDown() &&
                         _receiver->getAux2State() &&
+                        _receiver->aux2Changed() &&
                         !_failsafe &&
                         safeAngle(AXIS_ROLL) &&
-                        safeAngle(AXIS_PITCH)) {
+                        safeAngle(AXIS_PITCH &&
+                        !_lowBattery)) {
                     _state.armed = true;
                     _yawInitial = _state.UAVState->eulerAngles[AXIS_YAW]; // grab yaw for headless mode
                 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -264,10 +264,7 @@ namespace hf {
                 }
 
                 // Disarm
-                if (  _state.armed && 
-                      !_receiver->getAux2State() &&
-                      !_state.executingMission &&
-                      !_state.executingStack) {
+                if (  _state.armed && !_receiver->getAux2State()) {
                     _state.armed = false;
                 }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -276,7 +276,7 @@ namespace hf {
                 if (!_receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial)) return;
 
                 // Update ratePid with cyclic demands
-                _ratePid->updateReceiver(_receiver->demands, _receiver->throttleIsDown());
+                _ratePid->updateReceiver(_receiver->demands, _receiver->throttleIsDown(), _state.executingStack || _state.executingMission);
                 
                 // Check if aux1 has changed value. In that case, stop executing 
                 // actions and return control to TX
@@ -317,8 +317,8 @@ namespace hf {
                     
                     digitalWrite(26, HIGH);
                     
-                        _state.armed = true;
-                        _yawInitial = _state.UAVState->eulerAngles[AXIS_YAW]; // grab yaw for headless mode
+                    _state.armed = true;
+                    _yawInitial = _state.UAVState->eulerAngles[AXIS_YAW]; // grab yaw for headless mode
                     // Reset estimations each time the quad is armed 
                     eskf.init();
                 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -40,6 +40,7 @@
 #include "filters/eskf.hpp"
 
 #include "planners/mission.hpp"
+#include "planners/individual.hpp"
 
 namespace hf {
 
@@ -59,11 +60,12 @@ namespace hf {
             tx_calibration_t _tx_calibration;
 
             // Passed to Hackflight::init() for a particular build
-            Board      * _board;
-            Receiver   * _receiver;
-            Rate       * _ratePid;
-            Mixer      * _mixer;
+            Board               * _board;
+            Receiver            * _receiver;
+            Rate                * _ratePid;
+            Mixer               * _mixer;
             MissionPlanner      planner;
+            IndividualPlanner   individualPlanner;
 
             ESKF eskf = ESKF();
 
@@ -728,6 +730,8 @@ namespace hf {
                 _state.armed = armed;
                 // Will be set to true when start mission message is received
                 _state.executingMission = false;
+                // Will be set to true when an inmediate action is to be received
+                _state.executingStack = false;
 
                 // Initialize MPS parser for serial comms
                 MspParser::init();
@@ -737,6 +741,8 @@ namespace hf {
 
                 // Initialize the planner
                 planner.init(PARAMETER_SLOTS);
+                // and the stack planner
+                individualPlanner.init();
                 // XXX Only for debuging purposes.
                 // planner.printMission();
                 // readEEPROM();

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -696,6 +696,82 @@ namespace hf {
                 _state.armed = false;
                 digitalWrite(25, LOW);
             }
+            
+            // Action handlers
+            virtual void handle_WP_ARM_Request(uint8_t & code) override
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_DISARM_Request(uint8_t & code) override
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_LAND_Request(uint8_t & code) override
+            {
+                (void)code;
+            }
+
+            virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
+            {
+                (void)meters;
+                (void)code;
+            }
+
+            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code) override
+            {
+                (void)speed;
+                (void)code;
+            }
+
+            virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code) override
+            {
+                (void)seconds;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code) override
+            {
+                (void)degrees;
+                (void)code;
+            }
+
+            virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code) override
+            {
+                (void)degrees;
+                (void)code;
+            }
 
         public:
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -308,6 +308,7 @@ namespace hf {
             void checkPlanner(void)
             {
               if (_state.executingMission == false) return;
+              planner.executeAction(_state, _demands);
             }
 
             // XXX only for debuging purposes

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -248,11 +248,22 @@ namespace hf {
 
                 // Update ratePid with cyclic demands
                 _ratePid->updateReceiver(_receiver->demands, _receiver->throttleIsDown());
+                
+                // Check if aux1 has changed value. In that case, stop executing 
+                // actions and return control to TX
+                if (_receiver->aux1Changed())
+                {
+                    _state.executingMission = false;
+                    _state.executingStack = false;
+                    planner.reset();
+                    individualPlanner.reset();
+                }
 
                 // Disarm
                 if (  _state.armed && 
                       !_receiver->getAux2State() &&
-                      !_state.executingMission) {
+                      !_state.executingMission &&
+                      !_state.executingStack) {
                     _state.armed = false;
                 }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -155,7 +155,7 @@ namespace hf {
 
                 // Use updated demands to run motors
                 if (_state.armed && !_failsafe && 
-                  (!_receiver->throttleIsDown() || _state.executingStack || _state.executingAction))
+                  (!_receiver->throttleIsDown() || _state.executingStack || _state.executingMission))
                 {
                   _mixer->runArmed(_demands);
                 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -158,7 +158,6 @@ namespace hf {
                   (!_receiver->throttleIsDown() || _state.executingStack || _state.executingAction))
                 {
                   _mixer->runArmed(_demands);
-
                 }
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -212,7 +212,7 @@ namespace hf {
 
                     // XXX we should allow associating PID controllers with particular aux states
                     if (pidController->auxState <= auxState) {
-                        if (pidController->modifyDemands(*_state.UAVState, _demands, currentTime) && pidController->shouldFlashLed()) {
+                        if (pidController->modifyDemands(_state, _demands, currentTime) && pidController->shouldFlashLed()) {
                             shouldFlash = true;
                         }
                     }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -154,7 +154,9 @@ namespace hf {
                 runPidControllers();
 
                 // Use updated demands to run motors
-                if (_state.armed && !_failsafe && !_receiver->throttleIsDown()) {
+                if (_state.armed && !_failsafe && 
+                  (!_receiver->throttleIsDown() || _state.executingStack || _state.executingAction))
+                {
                   _mixer->runArmed(_demands);
 
                 }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -86,6 +86,7 @@ namespace hf {
 
             // Demands sent to mixer
             demands_t _demands;
+            uint8_t REMOTE_DEMANDS = 4;
 
             // Safety
             bool _safeToArm;
@@ -170,7 +171,8 @@ namespace hf {
             void updateControlSignal(void)
             {
                 // For PID control, start with demands from receiver
-                memcpy(&_demands, &_receiver->demands, sizeof(demands_t));
+                // memcpy(&_demands, &_receiver->demands, sizeof(demands_t));
+                memcpy(&_demands, &_receiver->demands, REMOTE_DEMANDS * sizeof(float));
 
                 runPidControllers();
 
@@ -782,7 +784,7 @@ namespace hf {
 
             virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
             {
-                individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData / 100.f);
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData / 100.0);
                 switchToStackExecution();
             }
 
@@ -812,7 +814,7 @@ namespace hf {
 
             virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
             {
-                individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData / 100.f);
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData / 100.0);
                 switchToStackExecution();
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -691,6 +691,7 @@ namespace hf {
                 // as well as stop executing a mission
                 (void)flag;
                 _state.executingMission = false;
+                _state.armed = false;
                 digitalWrite(25, LOW);
             }
 
@@ -737,7 +738,8 @@ namespace hf {
                 // Initialize the planner
                 planner.init(PARAMETER_SLOTS);
                 // XXX Only for debuging purposes.
-                //planner.printMission();
+                // planner.printMission();
+                // readEEPROM();
 
                 // Tell the mixer which board to use
                 _mixer->board = board;

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -247,6 +247,10 @@ namespace hf {
 
             void checkReceiver(void)
             {
+              
+                // Set LED based on arming status                
+                _board->showArmedStatus(_state.armed);
+              
                 // Check whether receiver data is available
                 if (!_receiver->getDemands(_state.UAVState->eulerAngles[AXIS_YAW] - _yawInitial)) return;
 
@@ -291,9 +295,6 @@ namespace hf {
                 if (_state.armed && _receiver->throttleIsDown() && !_state.executingMission) {
                     _mixer->cutMotors();
                 }
-
-                // Set LED based on arming status
-                _board->showArmedStatus(_state.armed);
 
             } // checkReceiver
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -307,10 +307,19 @@ namespace hf {
                 _sensors[_sensor_count++] = sensor;
             }
 
-            void checkPlanner(void)
+            void checkPlanners(void)
             {
-              if (_state.executingMission == false) return;
-              planner.executeAction(_state, _demands);
+                if (_state.executingStack)
+                {
+                    // turn off mission execution since individual commands have
+                    // a higher priority
+                    _state.executingMission = false;
+                    individualPlanner.executeAction(_state, _demands);
+                }
+                else if (_state.executingMission)
+                {
+                   planner.executeAction(_state, _demands);
+                }
             }
 
             // XXX only for debuging purposes
@@ -700,77 +709,74 @@ namespace hf {
             // Action handlers
             virtual void handle_WP_ARM_Request(uint8_t & code) override
             {
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_ARM, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_DISARM_Request(uint8_t & code) override
             {
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_DISARM, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_LAND_Request(uint8_t & code) override
             {
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_LAND, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_FORWARD, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_BACKWARD, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_LEFT, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_RIGHT, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
             {
-                (void)meters;
-                (void)code;
-            }
-
-            virtual void handle_WP_CHANGE_SPEED_Request(uint8_t & speed, uint8_t & code) override
-            {
-                (void)speed;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code) override
             {
-                (void)seconds;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_HOVER, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code) override
             {
-                (void)degrees;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CW, _lastCommandData);
+                _state.executingStack = true;
             }
 
             virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code) override
             {
-                (void)degrees;
-                (void)code;
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CCW, _lastCommandData);
+                _state.executingStack = true;
             }
 
         public:
@@ -860,8 +866,8 @@ namespace hf {
             {
                 // Check Battery
                 checkBattery();
-                // Check planner
-                checkPlanner();
+                // Check planners
+                checkPlanners();
                 // Grab control signal if available
                 checkReceiver();
                 // Check serials for messages

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -39,7 +39,8 @@
 
 #include "filters/eskf.hpp"
 
-#include "planner.hpp"
+//#include "planner.hpp"
+#include "planners/mission.hpp"
 
 namespace hf {
 
@@ -63,7 +64,7 @@ namespace hf {
             Receiver   * _receiver;
             Rate       * _ratePid;
             Mixer      * _mixer;
-            Planner      planner;
+            MissionPlanner      planner;
 
             ESKF eskf = ESKF();
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -98,6 +98,13 @@ namespace hf {
             // Support for headless mode
             float _yawInitial;
 
+            void switchToStackExecution()
+            {
+                _state.executingStack = true;
+                _state.executingMission = false;
+                planner.reset();
+            }
+
             bool safeAngle(uint8_t axis)
             {
                 return fabs(_state.UAVState->eulerAngles[axis]) < _ratePid->maxArmingAngle;
@@ -142,7 +149,6 @@ namespace hf {
                 }
                 lastTime = _board->getTime();
               }
-
 
             }
 
@@ -722,73 +728,73 @@ namespace hf {
             virtual void handle_WP_ARM_Request(uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_ARM, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_DISARM_Request(uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_DISARM, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_LAND_Request(uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_LAND, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_FORWARD_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_FORWARD, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_BACKWARD_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_BACKWARD, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_LEFT_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_LEFT, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_GO_RIGHT_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_GO_RIGHT, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_HOVER_Request(uint8_t & seconds, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_HOVER, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_TURN_CW_Request(uint8_t & degrees, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CW, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
             virtual void handle_WP_TURN_CCW_Request(uint8_t & degrees, uint8_t & code) override
             {
                 individualPlanner.addActionToStack(_state, individualPlanner.WP_TURN_CCW, _lastCommandData);
-                _state.executingStack = true;
+                switchToStackExecution();
             }
 
         public:

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -111,16 +111,17 @@ namespace hf {
             {
                 bool safe = false;
 
-                if (_safeToArm && !_state.armed && 
-                    !_failsafe && !_lowBattery &&
+                if (!_state.armed && !_failsafe && !_lowBattery &&
                     safeAngle(AXIS_ROLL) && safeAngle(AXIS_PITCH))
                 {
                     safe = true; 
                 }
+
                 if (_hasPositioningBoard && !_positionBoardConnected)
                 {
                     safe = false;
                 }
+
                 return safe;
             }
 
@@ -293,9 +294,8 @@ namespace hf {
                 if (!_safeToArm) {
                     _safeToArm = !_receiver->getAux2State();
                 }
-
-                // Arm (after lots of safety checks!)
-                if ( safeToArm() &&
+                
+                if (_safeToArm && safeToArm() &&
                     _receiver->throttleIsDown() &&
                     _receiver->getAux2State() &&
                     _receiver->aux2Changed()

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -264,7 +264,7 @@ namespace hf {
                 }
 
                 // Disarm
-                if (  _state.armed && !_receiver->getAux2State()) {
+                if (  _state.armed && !_receiver->getAux2State() && _receiver->aux2Changed()) {
                     _state.armed = false;
                 }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -247,7 +247,9 @@ namespace hf {
                 _ratePid->updateReceiver(_receiver->demands, _receiver->throttleIsDown());
 
                 // Disarm
-                if (_state.armed && !_receiver->getAux2State()) {
+                if (  _state.armed && 
+                      !_receiver->getAux2State() &&
+                      !_state.executingMission) {
                     _state.armed = false;
                 }
 
@@ -269,7 +271,7 @@ namespace hf {
                 }
 
                 // Cut motors on throttle-down
-                if (_state.armed && _receiver->throttleIsDown()) {
+                if (_state.armed && _receiver->throttleIsDown() && !_state.executingMission) {
                     _mixer->cutMotors();
                 }
 
@@ -684,7 +686,7 @@ namespace hf {
             
             virtual void handle_SET_EMERGENCY_STOP_Request(uint8_t  flag)
             {
-                // XXX This should trigger a land action 
+                // XXX This should trigger a land action or a disarm
                 (void)flag;
                 digitalWrite(25, LOW);
             }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -92,9 +92,6 @@ namespace hf {
             bool _failsafe;
             bool _lowBattery;
 
-            // XXX Store it as an MSP parameter
-            const float _BAT_MIN = 3.3; // Minimum voltage for 1S Battery
-
             // Support for headless mode
             float _yawInitial;
 
@@ -124,7 +121,7 @@ namespace hf {
               if (_board->getTime() - lastTime > 0.5)
               {
                 // Look if the battery is below the limit
-                if (_state.batteryVoltage < _BAT_MIN && _state.batteryVoltage > 2.5)
+                if (_state.batteryVoltage < _board->getLowBatteryLimit() && _state.batteryVoltage > 2.5)
                 {
                   // Save the first time it detects low battery
                   lastTimeLowBattery = ((isLastLowBattery) ? lastTimeLowBattery:_board->getTime());
@@ -137,6 +134,9 @@ namespace hf {
                   {
                     pinMode(25, OUTPUT);
                     digitalWrite(25, LOW);
+                    // XXX Ring the buzzer 
+                    individualPlanner.addActionToStack(_state, individualPlanner.WP_LAND, 0);
+                    switchToStackExecution();
                   }
 
                   isLastLowBattery = true;
@@ -233,14 +233,14 @@ namespace hf {
             void checkFailsafe(void)
             {
                 if (_state.armed &&
-                   (_receiver->lostSignal(_receiver->getBypassReceiver()) || _board->isBatteryLow())) {
+                   (_receiver->lostSignal(_receiver->getBypassReceiver()))) {
                     _mixer->cutMotors();
                     _state.armed = false;
                     _failsafe = true;
                     _board->showArmedStatus(false);
                     if (_receiver->getLostSignal())
                     {
-                      _receiver->setBypassReceiver(false);
+                        _receiver->setBypassReceiver(false);
                     }
                 }
             }

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -306,7 +306,7 @@ namespace hf {
                 }
 
                 // Cut motors on throttle-down
-                if (_state.armed && _receiver->throttleIsDown() && !_state.executingMission) {
+                if (_state.armed && _receiver->throttleIsDown() && !_state.executingMission && !_state.executingStack) {
                     _mixer->cutMotors();
                 }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -741,7 +741,7 @@ namespace hf {
 
             virtual void handle_WP_TAKE_OFF_Request(uint8_t & meters, uint8_t & code) override
             {
-                individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData);
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_TAKE_OFF, _lastCommandData / 100.f);
                 switchToStackExecution();
             }
 
@@ -771,7 +771,7 @@ namespace hf {
 
             virtual void handle_WP_CHANGE_ALTITUDE_Request(uint8_t & meters, uint8_t & code) override
             {
-                individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData);
+                individualPlanner.addActionToStack(_state, individualPlanner.WP_CHANGE_ALTITUDE, _lastCommandData / 100.f);
                 switchToStackExecution();
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -687,7 +687,9 @@ namespace hf {
             virtual void handle_SET_EMERGENCY_STOP_Request(uint8_t  flag)
             {
                 // XXX This should trigger a land action or a disarm
+                // as well as stop executing a mission
                 (void)flag;
+                _state.executingMission = false;
                 digitalWrite(25, LOW);
             }
 

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -39,7 +39,6 @@
 
 #include "filters/eskf.hpp"
 
-//#include "planner.hpp"
 #include "planners/mission.hpp"
 
 namespace hf {

--- a/src/hackflight.hpp
+++ b/src/hackflight.hpp
@@ -133,13 +133,11 @@ namespace hf {
                   // XXX it might be necessary to trigger the low battery action from here
                   _lowBattery = (_board->getTime() - lastTimeLowBattery > 5);
 
-                  // ---- Provisional
                   if (_lowBattery)
                   {
                     pinMode(25, OUTPUT);
                     digitalWrite(25, LOW);
                   }
-                  // ---- Provisional
 
                   isLastLowBattery = true;
                 }
@@ -329,14 +327,11 @@ namespace hf {
             {
                 if (_state.executingStack)
                 {
-                    // turn off mission execution since individual commands have
-                    // a higher priority
-                    _state.executingMission = false;
                     individualPlanner.executeAction(_state, _demands);
                 }
                 else if (_state.executingMission)
                 {
-                   planner.executeAction(_state, _demands);
+                    planner.executeAction(_state, _demands);
                 }
             }
 
@@ -720,6 +715,7 @@ namespace hf {
                 // as well as stop executing a mission
                 (void)flag;
                 _state.executingMission = false;
+                _state.executingStack = false;
                 _state.armed = false;
                 digitalWrite(25, LOW);
             }

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -353,12 +353,12 @@ namespace hf {
                 // they can be queried via MSP
                 h.setParams(_hasPositioningBoard, _isMosquito90, _positionBoardConnected);
                 
-                // XXX Debuging
+                // XXX Testing: To be removed
                 // hardcodeMission();
                 
             } // init
             
-            // XXX Testing
+            // XXX Testing: To be removed
             void hardcodeMission(void)
             {
               EEPROM.write(150, 1);   // Arm

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -333,7 +333,24 @@ namespace hf {
                 // via MSP
                 h.setParams(_hasPositioningBoard, _isMosquito90, _positionBoardConnected);
                 
+                // XXX Debuging
+                // hardcodeMission();
+                
             } // init
+            
+            // XXX Testing
+            void hardcodeMission(void)
+            {
+              EEPROM.write(150, 1);   // Arm
+              // EEPROM.write(151, 0);
+              EEPROM.write(151, 4);   // Takeoff to 1 m
+              EEPROM.write(152, 1);
+              EEPROM.write(153, 11);  // Hover for 3 seconds
+              EEPROM.write(154, 3);
+              EEPROM.write(155, 3);   // Land
+              // EEPROM.write(155, 0);
+              EEPROM.write(156, 2);   // Disarm
+            }
 
     }; // class HackflightWrapper
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -305,12 +305,12 @@ namespace hf {
                         _minAltitude);  // Min altitude
                     h.addPidController(althold, 2);
 
-                    // hf::PositionHold * poshold = new hf::PositionHold(
-                    //     0.0,            // Position Hold P -> this will set velTarget to 0
-                    //     _altHoldVelP,   // Position Hold Velocity P
-                    //     _altHoldVelI,   // Position Hold Velocity I
-                    //     _altHoldVelD);   // Position Hold Velocity D
-                    // h.addPidController(poshold, 2);
+                    hf::PositionHold * poshold = new hf::PositionHold(
+                        0.0,            // Position Hold P -> this will set velTarget to 0
+                        _posHoldVelP,   // Position Hold Velocity P
+                        _posHoldVelI,   // Position Hold Velocity I
+                        _posHoldVelD);   // Position Hold Velocity D
+                    h.addPidController(poshold, 2);
 
                 }
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -290,9 +290,11 @@ namespace hf {
                   _gyroYawP,
                   _gyroYawI,
                   _demandsToRate);
-
+                ratePid->setPIDType(RATE);
+                
                 hf::Level * level = new hf::Level(_levelP);  // Pitch Level P
                 level->setDemandsToRate(_demandsToRate);
+                level->setPIDType(LEVEL);
 
                 // Add additional sensors
                 if (_hasPositioningBoard)
@@ -303,6 +305,7 @@ namespace hf {
                         _altHoldVelI,   // Altitude Hold Velocity I
                         _altHoldVelD,   // Altitude Hold Velocity D
                         _minAltitude);  // Min altitude
+                    althold->setPIDType(ALTHOLD);
                     h.addPidController(althold, 0);
 
                     hf::PositionHold * poshold = new hf::PositionHold(
@@ -310,6 +313,7 @@ namespace hf {
                         _posHoldVelP,   // Position Hold Velocity P
                         _posHoldVelI,   // Position Hold Velocity I
                         _posHoldVelD);   // Position Hold Velocity D
+                    poshold->setPIDType(POSHOLD);
                     h.addPidController(poshold, 0);
 
                 }

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -312,7 +312,7 @@ namespace hf {
                         0.0,            // Position Hold P -> this will set velTarget to 0
                         _posHoldVelP,   // Position Hold Velocity P
                         _posHoldVelI,   // Position Hold Velocity I
-                        _posHoldVelD);   // Position Hold Velocity D
+                        _posHoldVelD);  // Position Hold Velocity D
                     poshold->setPIDType(POSHOLD);
                     h.addPidController(poshold, 0);
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -303,14 +303,14 @@ namespace hf {
                         _altHoldVelI,   // Altitude Hold Velocity I
                         _altHoldVelD,   // Altitude Hold Velocity D
                         _minAltitude);  // Min altitude
-                    h.addPidController(althold, 2);
+                    h.addPidController(althold, 0);
 
                     hf::PositionHold * poshold = new hf::PositionHold(
                         0.0,            // Position Hold P -> this will set velTarget to 0
                         _posHoldVelP,   // Position Hold Velocity P
                         _posHoldVelI,   // Position Hold Velocity I
                         _posHoldVelD);   // Position Hold Velocity D
-                    h.addPidController(poshold, 2);
+                    h.addPidController(poshold, 0);
 
                 }
 

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -346,7 +346,7 @@ namespace hf {
                     h.addSensor(opticalflow);
                     h.eskf.addSensorESKF(opticalflow);
                     
-                    _positionBoardConnected = _rangeConnected & _opticalConnected;
+                    _positionBoardConnected = _rangeConnected && _opticalConnected;
                 }
 
                 // Set parameters in hackflight instance so that 

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -328,6 +328,19 @@ namespace hf {
                         serialize8(_checksum);
                         } break;
 
+                    case 103:
+                    {
+                        float velx = 0;
+                        float vely = 0;
+                        float velz = 0;
+                        handle_GET_VELOCITIES_Request(velx, vely, velz);
+                        prepareToSendFloats(3);
+                        sendFloat(velx);
+                        sendFloat(vely);
+                        sendFloat(velz);
+                        serialize8(_checksum);
+                        } break;
+
                     case 121:
                     {
                         float c1 = 0;
@@ -910,6 +923,14 @@ namespace hf {
                         handle_RAW_IMU_Data(accx, accy, accz, gyrx, gyry, gyrz, magx, magy, magz);
                         } break;
 
+                    case 103:
+                    {
+                        float velx = getArgument(0);
+                        float vely = getArgument(1);
+                        float velz = getArgument(2);
+                        handle_GET_VELOCITIES_Data(velx, vely, velz);
+                        } break;
+
                     case 121:
                     {
                         float c1 = getArgument(0);
@@ -1161,6 +1182,20 @@ namespace hf {
                 (void)magx;
                 (void)magy;
                 (void)magz;
+            }
+
+            virtual void handle_GET_VELOCITIES_Request(float & velx, float & vely, float & velz)
+            {
+                (void)velx;
+                (void)vely;
+                (void)velz;
+            }
+
+            virtual void handle_GET_VELOCITIES_Data(float & velx, float & vely, float & velz)
+            {
+                (void)velx;
+                (void)vely;
+                (void)velz;
             }
 
             virtual void handle_RC_NORMAL_Request(float & c1, float & c2, float & c3, float & c4, float & c5, float & c6)
@@ -1772,6 +1807,35 @@ namespace hf {
                 bytes[23] = CRC8(&bytes[3], 20);
 
                 return 24;
+            }
+
+            static uint8_t serialize_GET_VELOCITIES_Request(uint8_t bytes[])
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 60;
+                bytes[3] = 0;
+                bytes[4] = 103;
+                bytes[5] = 103;
+
+                return 6;
+            }
+
+            static uint8_t serialize_GET_VELOCITIES(uint8_t bytes[], float  velx, float  vely, float  velz)
+            {
+                bytes[0] = 36;
+                bytes[1] = 77;
+                bytes[2] = 62;
+                bytes[3] = 12;
+                bytes[4] = 103;
+
+                memcpy(&bytes[5], &velx, sizeof(float));
+                memcpy(&bytes[9], &vely, sizeof(float));
+                memcpy(&bytes[13], &velz, sizeof(float));
+
+                bytes[17] = CRC8(&bytes[3], 14);
+
+                return 18;
             }
 
             static uint8_t serialize_RC_NORMAL_Request(uint8_t bytes[])

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -40,6 +40,7 @@ namespace hf {
             // Number of EEPROM reserved slots for parameters
             static const int PARAMETER_SLOTS = 150;
             uint8_t MISSION_COMMANDS[13] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+            uint8_t _lastCommandData = 0;
             
         protected:
 
@@ -187,15 +188,23 @@ namespace hf {
 
             void processMissionCommand(uint8_t command)
             {
-                if (incomingMission && isMissionCommand(command))
+                if (isMissionCommand(command))
                 {
-                    EEPROM.write(EEPROMindex, command);
-                    EEPROMindex += 1;
+                    int commandData = -1;
                     if (command != 1 && command != 2 && command != 3)
                     {
-                        uint8_t commandData = readCommandData();
-                        EEPROM.write(EEPROMindex, commandData);
+                        commandData = readCommandData();
+                        _lastCommandData = (uint8_t)commandData;
+                    }
+                    if (incomingMission)
+                    {
+                        EEPROM.write(EEPROMindex, command);
                         EEPROMindex += 1;
+                        if (commandData!=-1)
+                        {
+                          EEPROM.write(EEPROMindex, (uint8_t)commandData);
+                          EEPROMindex += 1;
+                        }
                     }
                 }
             }

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -39,6 +39,7 @@ namespace hf {
             
             // Number of EEPROM reserved slots for parameters
             static const int PARAMETER_SLOTS = 150;
+            uint8_t MISSION_COMMANDS[13] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
 
         private:
 
@@ -183,7 +184,7 @@ namespace hf {
 
             void processMissionCommand(uint8_t command)
             {
-                if (incomingMission && command != 23)
+                if (incomingMission && isMissionCommand(command))
                 {
                     EEPROM.write(EEPROMindex, command);
                     EEPROMindex += 1;
@@ -199,6 +200,15 @@ namespace hf {
             uint8_t readCommandData(void)
             {
                 return _inBuf[_inBufIndex++] & 0xff;
+            }
+
+            bool isMissionCommand(uint8_t command)
+            {
+                for(int i=0; i<sizeof(MISSION_COMMANDS)/sizeof(MISSION_COMMANDS[0]); ++i)
+                {
+                    if (command == MISSION_COMMANDS[i]) return true;
+                }
+                return false;
             }
 
         protected:

--- a/src/mspparser.hpp
+++ b/src/mspparser.hpp
@@ -40,6 +40,10 @@ namespace hf {
             // Number of EEPROM reserved slots for parameters
             static const int PARAMETER_SLOTS = 150;
             uint8_t MISSION_COMMANDS[13] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+            
+        protected:
+
+          bool incomingMission = false;
 
         private:
 
@@ -47,7 +51,6 @@ namespace hf {
             static const int OUTBUF_SIZE = 128;
 
             int EEPROMindex = PARAMETER_SLOTS;
-            bool incomingMission = false;
 
             typedef enum serialState_t {
                 IDLE,

--- a/src/pidcontroller.hpp
+++ b/src/pidcontroller.hpp
@@ -30,13 +30,19 @@ namespace hf {
 
         protected:
 
-        virtual bool modifyDemands(state_t & state, demands_t & demands, float currentTime) = 0;
+          virtual bool modifyDemands(state_t & state, demands_t & demands, float currentTime) = 0;
         
-        virtual void resetErrors(void) {}
+          virtual void resetErrors(void) {}
 
-        virtual bool shouldFlashLed(void) { return false; }
+          virtual bool shouldFlashLed(void) { return false; }
 
-        uint8_t auxState;
+          uint8_t auxState;
+        
+          // To enable activation and deactivation of controllers at runtime
+          void modifyAuxState(uint8_t aux) 
+          {
+              auxState = aux;
+          }
 
     };  // class PID_Controller
 

--- a/src/pidcontroller.hpp
+++ b/src/pidcontroller.hpp
@@ -30,7 +30,7 @@ namespace hf {
 
         protected:
 
-        virtual bool modifyDemands(eskf_state_t & state, demands_t & demands, float currentTime) = 0;
+        virtual bool modifyDemands(state_t & state, demands_t & demands, float currentTime) = 0;
 
         virtual bool shouldFlashLed(void) { return false; }
 

--- a/src/pidcontroller.hpp
+++ b/src/pidcontroller.hpp
@@ -37,11 +37,25 @@ namespace hf {
           virtual bool shouldFlashLed(void) { return false; }
 
           uint8_t auxState;
+          
+          ControllerType_t _PIDType;
         
           // To enable activation and deactivation of controllers at runtime
           void modifyAuxState(uint8_t aux) 
           {
               auxState = aux;
+          }
+          
+        public:
+          
+          void setPIDType(ControllerType_t pidType)
+          {
+              _PIDType = pidType;
+          }
+          
+          ControllerType_t getPIDType(void)
+          {
+              return _PIDType;
           }
 
     };  // class PID_Controller

--- a/src/pidcontroller.hpp
+++ b/src/pidcontroller.hpp
@@ -37,14 +37,9 @@ namespace hf {
           virtual bool shouldFlashLed(void) { return false; }
 
           uint8_t auxState;
+          uint8_t _originalAuxState;
           
           ControllerType_t _PIDType;
-        
-          // To enable activation and deactivation of controllers at runtime
-          void modifyAuxState(uint8_t aux) 
-          {
-              auxState = aux;
-          }
           
         public:
           
@@ -56,6 +51,19 @@ namespace hf {
           ControllerType_t getPIDType(void)
           {
               return _PIDType;
+          }
+
+          // To enable activation and deactivation of controllers at runtime
+          void deactivate(void) 
+          {
+              // aux state cannot be 3 with current transmiters so setting
+              // aux state to 3 will deactivate the controller
+              auxState = 3;
+          }
+          
+          void activate(void)
+          {
+              auxState = 0;
           }
 
     };  // class PID_Controller

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -62,13 +62,15 @@ namespace hf {
                   float correction = 0;
                   if (setpointIsActive(state))
                   {
-                    // Correct based on setpoint
-                    if(setpoint.gotSetpointCorrection(demands.setpoint[2],
-                          state.UAVState->position[2], 
-                          state.UAVState->linearVelocities[2], 
-                          currentTime, correction)){
-                      demands.throttle = correction + HOVER_THROTTLE;
-                      return true;                      
+                      // Correct based on setpoint
+                      if(setpoint.gotSetpointCorrection(demands.setpoint[2],
+                            state.UAVState->position[2], 
+                            state.UAVState->linearVelocities[2], 
+                            currentTime, correction))
+                    {
+                                demands.throttle = correction + HOVER_THROTTLE;
+                                Serial.println(demands.throttle);
+                                return true;                      
                     }
                   } else {
                     // Correct based on throttle

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -48,13 +48,13 @@ namespace hf {
 
           protected:
             
-              bool modifyDemands(eskf_state_t & state, demands_t & demands, float currentTime)
+              bool modifyDemands(state_t & state, demands_t & demands, float currentTime)
               {
                   // Don't do anything till we've reached sufficient altitude
-                  if (state.position[2] < _minAltitude) return false;
+                  if (state.UAVState->position[2] < _minAltitude) return false;
 
                   float correction = 0;
-                  if (setpoint.gotCorrection(demands.throttle, state.position[2], state.linearVelocities[2], currentTime, correction)) {
+                  if (setpoint.gotCorrection(demands.throttle, state.UAVState->position[2], state.UAVState->linearVelocities[2], currentTime, correction)) {
                       demands.throttle = correction + HOVER_THROTTLE;
                       return true;
                   }

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -63,12 +63,6 @@ namespace hf {
                   float correction = 0;
                   if (setpointIsActive(state))
                   {
-                      if (state.takingOff)
-                      {
-                          demands.throttle = TAKEOFF_THROTTLE;
-                          return true;
-                      }
-
                       // Correct based on setpoint
                       if(setpoint.gotSetpointCorrection(demands.setpoint[2],
                             state.UAVState->position[2], 

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -48,7 +48,7 @@ namespace hf {
 
               bool setpointIsActive(state_t & state)
               {
-                  return state.executingMission;
+                  return (state.executingMission || state.executingStack);
               }
 
           protected:

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -46,6 +46,11 @@ namespace hf {
               // Minimum altitude, set by constructor
               float _minAltitude;
 
+              bool setpointIsActive(state_t & state)
+              {
+                  return state.executingMission;
+              }
+
           protected:
             
               bool modifyDemands(state_t & state, demands_t & demands, float currentTime)
@@ -55,8 +60,9 @@ namespace hf {
                   // if (state.UAVState->position[2] < _minAltitude) return false;
 
                   float correction = 0;
-                  if (state.executingMission)
+                  if (setpointIsActive(state))
                   {
+                    // Correct based on setpoint
                     if(setpoint.gotSetpointCorrection(demands.setpoint[2],
                           state.UAVState->position[2], 
                           state.UAVState->linearVelocities[2], 
@@ -65,6 +71,7 @@ namespace hf {
                       return true;                      
                     }
                   } else {
+                    // Correct based on throttle
                     if (setpoint.gotManualCorrection(demands.throttle, 
                             state.UAVState->position[2], 
                             state.UAVState->linearVelocities[2], 

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -37,6 +37,7 @@ namespace hf {
               // Arbitrary constants
               const float WINDUP_MAX             = 2.00f;
               const float HOVER_THROTTLE         = 0.00f;
+              const float TAKEOFF_THROTTLE       = 1.00f;
               const float Vz_MAX                 = 1.00f; 
               const float Vz_MIN                 = 0.00f;
 
@@ -62,25 +63,31 @@ namespace hf {
                   float correction = 0;
                   if (setpointIsActive(state))
                   {
+                      if (state.takingOff)
+                      {
+                          demands.throttle = TAKEOFF_THROTTLE;
+                          return true;
+                      }
+
                       // Correct based on setpoint
                       if(setpoint.gotSetpointCorrection(demands.setpoint[2],
                             state.UAVState->position[2], 
                             state.UAVState->linearVelocities[2], 
                             currentTime, correction))
-                    {
-                                demands.throttle = correction + HOVER_THROTTLE;
-                                Serial.println(demands.throttle);
-                                return true;                      
-                    }
+                      {
+                          demands.throttle = correction + HOVER_THROTTLE;
+                          return true;                      
+                      }
                   } else {
-                    // Correct based on throttle
-                    if (setpoint.gotManualCorrection(demands.throttle, 
+                      // Correct based on throttle
+                      if (setpoint.gotManualCorrection(demands.throttle, 
                             state.UAVState->position[2], 
                             state.UAVState->linearVelocities[2], 
-                            currentTime, correction)) {
-                        demands.throttle = correction + HOVER_THROTTLE;
-                        return true;
-                    }
+                            currentTime, correction)) 
+                      {
+                          demands.throttle = correction + HOVER_THROTTLE;
+                          return true;
+                      }
                   }
                   return false;
 

--- a/src/pidcontrollers/althold.hpp
+++ b/src/pidcontrollers/althold.hpp
@@ -50,15 +50,29 @@ namespace hf {
             
               bool modifyDemands(state_t & state, demands_t & demands, float currentTime)
               {
+                  // XXX Comment it now, rethink later
                   // Don't do anything till we've reached sufficient altitude
-                  if (state.UAVState->position[2] < _minAltitude) return false;
+                  // if (state.UAVState->position[2] < _minAltitude) return false;
 
                   float correction = 0;
-                  if (setpoint.gotCorrection(demands.throttle, state.UAVState->position[2], state.UAVState->linearVelocities[2], currentTime, correction)) {
+                  if (state.executingMission)
+                  {
+                    if(setpoint.gotSetpointCorrection(demands.setpoint[2],
+                          state.UAVState->position[2], 
+                          state.UAVState->linearVelocities[2], 
+                          currentTime, correction)){
                       demands.throttle = correction + HOVER_THROTTLE;
-                      return true;
+                      return true;                      
+                    }
+                  } else {
+                    if (setpoint.gotManualCorrection(demands.throttle, 
+                            state.UAVState->position[2], 
+                            state.UAVState->linearVelocities[2], 
+                            currentTime, correction)) {
+                        demands.throttle = correction + HOVER_THROTTLE;
+                        return true;
+                    }
                   }
-
                   return false;
 
               }

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -31,7 +31,7 @@
 #include "debug.hpp"
 #include "datatypes.hpp"
 #include "pidcontroller.hpp"
-#include "filters.h"
+// #include "filters.h"
 
 namespace hf {
 

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -66,14 +66,14 @@ namespace hf {
             {
             }
 
-            bool modifyDemands(eskf_state_t & state, demands_t & demands, float currentTime)
+            bool modifyDemands(state_t & state, demands_t & demands, float currentTime)
             {
                 (void)currentTime;
 
                 float _demands[2] = {demands.roll, demands.pitch};
                 for (int axis=0; axis<2; ++axis)
                 {
-                  float error = _demands[axis] * _demandsToAngle - state.eulerAngles[axis];
+                  float error = _demands[axis] * _demandsToAngle - state.UAVState->eulerAngles[axis];
                   _demands[axis] = error * PTerms[axis] + FEED_FORWARD * _demands[axis];
                 }
                 

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -45,6 +45,7 @@ namespace hf {
             float PTerms[2];
             
             float _demandsToAngle;
+            float _angleToDemands;
             float _demandsToRate;
 
         public:
@@ -59,6 +60,7 @@ namespace hf {
                 // Since we work in radians:
                 // _demandsToAngle = (maxAngle*PI/180) * 2
                 _demandsToAngle = maxAngle * 2 * M_PI / 180.0f;
+                _angleToDemands = 1 / _demandsToAngle;
                 _demandsToRate = demandsToRate;
             }
 
@@ -73,7 +75,9 @@ namespace hf {
                 float _demands[2] = {demands.roll, demands.pitch};
                 for (int axis=0; axis<2; ++axis)
                 {
-                  float error = _demands[axis] * _demandsToAngle - state.UAVState->eulerAngles[axis];
+                  // Target angle computation
+                  float targetAngle = state.executingMission ? demands.targetAngle[i] :  _demands[axis] * _demandsToAngle;
+                  float error = targetAngle - state.UAVState->eulerAngles[axis];
                   _demands[axis] = error * PTerms[axis] + FEED_FORWARD * _demands[axis];
                 }
                 

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -49,7 +49,7 @@ namespace hf {
             
             void computeReferenceDemands(float _demands[2], state_t &  state, demands_t & demands)
             {
-                if (state.executingMission)
+                if (state.executingMission || state.executingStack)
                 {
                     _demands[0] = demands.setpointAngle[0];
                     _demands[1] = demands.setpointAngle[1];

--- a/src/pidcontrollers/level.hpp
+++ b/src/pidcontrollers/level.hpp
@@ -76,7 +76,7 @@ namespace hf {
                 for (int axis=0; axis<2; ++axis)
                 {
                   // Target angle computation
-                  float targetAngle = state.executingMission ? demands.targetAngle[i] :  _demands[axis] * _demandsToAngle;
+                  float targetAngle = state.executingMission ? demands.setpointAngle[axis] :  _demands[axis] * _demandsToAngle;
                   float error = targetAngle - state.UAVState->eulerAngles[axis];
                   _demands[axis] = error * PTerms[axis] + FEED_FORWARD * _demands[axis];
                 }

--- a/src/pidcontrollers/poshold.hpp
+++ b/src/pidcontrollers/poshold.hpp
@@ -54,11 +54,11 @@ namespace hf {
 
         protected:
 
-        virtual bool modifyDemands(eskf_state_t & state, demands_t & demands, float currentTime) 
+        virtual bool modifyDemands(state_t & state, demands_t & demands, float currentTime) 
         {
-            bool correctedPitch = gotCorrection(setpointY, demands.pitch, state.positionX, state.velocityForward,   
+            bool correctedPitch = gotCorrection(setpointY, demands.pitch, state.UAVState->positionX, state.UAVState->velocityForward,   
                     currentTime);
-            bool correctedRoll  = gotCorrection(setpointX, demands.roll,  state.positionY, state.velocityRightward, 
+            bool correctedRoll  = gotCorrection(setpointX, demands.roll,  state.UAVState->positionY, state.UAVState->velocityRightward, 
                     currentTime);
 
             return correctedPitch || correctedRoll;

--- a/src/pidcontrollers/poshold.hpp
+++ b/src/pidcontrollers/poshold.hpp
@@ -56,9 +56,9 @@ namespace hf {
 
         virtual bool modifyDemands(state_t & state, demands_t & demands, float currentTime) 
         {
-            bool correctedPitch = gotCorrection(setpointY, demands.pitch, state.UAVState->positionX, state.UAVState->velocityForward,   
+            bool correctedPitch = gotCorrection(setpointY, demands.pitch, state.UAVState->position[0], state.UAVState->linearVelocities[0],   
                     currentTime);
-            bool correctedRoll  = gotCorrection(setpointX, demands.roll,  state.UAVState->positionY, state.UAVState->velocityRightward, 
+            bool correctedRoll  = gotCorrection(setpointX, demands.roll,  state.UAVState->position[1], state.UAVState->linearVelocities[1], 
                     currentTime);
 
             return correctedPitch || correctedRoll;

--- a/src/pidcontrollers/rate.hpp
+++ b/src/pidcontrollers/rate.hpp
@@ -253,13 +253,13 @@ namespace hf {
                 return true;
             }
 
-            void updateReceiver(demands_t & demands, bool throttleIsDown)
+            void updateReceiver(demands_t & demands, bool throttleIsDown, bool executingAction)
             {
                 // Compute proportion of cyclic demand compared to its maximum
                 // _proportionalCyclicDemand = Filter::max(fabs(demands.roll), fabs(demands.pitch)) / 0.5f;
                 
                 // When landed, reset integral component of PID
-                if (throttleIsDown) {
+                if (throttleIsDown && !executingAction) {
                     resetIntegral();
                 }
             }

--- a/src/pidcontrollers/rate.hpp
+++ b/src/pidcontrollers/rate.hpp
@@ -142,7 +142,7 @@ namespace hf {
             {
               _demands[0] = demands.roll;
               _demands[0] = demands.pitch;
-              _demands[2] = state.executingMission ? demands.setpointRate[2] : demands.yaw;
+              _demands[2] = (state.executingMission || state.executingStack) ? demands.setpointRate[2] : demands.yaw;
             }
 
         protected:

--- a/src/pidcontrollers/rate.hpp
+++ b/src/pidcontrollers/rate.hpp
@@ -219,7 +219,7 @@ namespace hf {
                 // For gyroYaw, P term comes directly from RC command or rate setpoint, and D term is zero
                 float yawError = _demands[2] * _demandsToRate - state.UAVState->angularVelocities[AXIS_YAW];
                 float ITermGyroYaw = computeITermGyro(yawError, _gyroYawI, _demands[2], state.UAVState->angularVelocities, deltat, AXIS_YAW);
-                _demands[2] = computePid(_gyroYawP, yawDemand, ITermGyroYaw, 0, state.UAVState->angularVelocities, _offsetError[AXIS_YAW], AXIS_YAW);
+                _demands[2] = computePid(_gyroYawP, _demands[2], ITermGyroYaw, 0, state.UAVState->angularVelocities, _offsetError[AXIS_YAW], AXIS_YAW);
 
                 // Prevent "gyroYaw jump" during gyroYaw correction
                 demands.yaw = Filter::constrainAbs(_demands[2], 0.1 + fabs(_demands[2]));

--- a/src/pidcontrollers/rate.hpp
+++ b/src/pidcontrollers/rate.hpp
@@ -193,7 +193,7 @@ namespace hf {
                 _DConstants[1] = gyroRollPitchD;
             }
 
-            bool modifyDemands(eskf_state_t & state, demands_t & demands, float currentTime)
+            bool modifyDemands(state_t & state, demands_t & demands, float currentTime)
             {
                 static float lastTime = 0.0;
                 
@@ -204,13 +204,13 @@ namespace hf {
                 _PTerm[1] = demands.pitch;
 
                 // Pitch, roll use Euler angles
-                demands.roll  = computeCyclicPid(demands.roll,  state.angularVelocities, deltat, AXIS_ROLL);
-                demands.pitch = computeCyclicPid(demands.pitch, state.angularVelocities, deltat, AXIS_PITCH);
+                demands.roll  = computeCyclicPid(demands.roll,  state.UAVState->angularVelocities, deltat, AXIS_ROLL);
+                demands.pitch = computeCyclicPid(demands.pitch, state.UAVState->angularVelocities, deltat, AXIS_PITCH);
 
                 // For gyroYaw, P term comes directly from RC command, and D term is zero
-                float yawError = demands.yaw * _demandsToRate - state.angularVelocities[AXIS_YAW];
-                float ITermGyroYaw = computeITermGyro(yawError, _gyroYawI, demands.yaw, state.angularVelocities, deltat, AXIS_YAW);
-                demands.yaw = computePid(_gyroYawP, demands.yaw, ITermGyroYaw, 0, state.angularVelocities, _offsetError[AXIS_YAW], AXIS_YAW);
+                float yawError = demands.yaw * _demandsToRate - state.UAVState->angularVelocities[AXIS_YAW];
+                float ITermGyroYaw = computeITermGyro(yawError, _gyroYawI, demands.yaw, state.UAVState->angularVelocities, deltat, AXIS_YAW);
+                demands.yaw = computePid(_gyroYawP, demands.yaw, ITermGyroYaw, 0, state.UAVState->angularVelocities, _offsetError[AXIS_YAW], AXIS_YAW);
 
                 // Prevent "gyroYaw jump" during gyroYaw correction
                 demands.yaw = Filter::constrainAbs(demands.yaw, 0.1 + fabs(demands.yaw));

--- a/src/pidcontrollers/rate.hpp
+++ b/src/pidcontrollers/rate.hpp
@@ -148,7 +148,7 @@ namespace hf {
             float _demandsToRate;
 
             // proportion of cyclic demand compared to its maximum
-            float _proportionalCyclicDemand;
+            // float _proportionalCyclicDemand;
 
             void resetIntegral(void)
             {
@@ -222,7 +222,7 @@ namespace hf {
             void updateReceiver(demands_t & demands, bool throttleIsDown)
             {
                 // Compute proportion of cyclic demand compared to its maximum
-                _proportionalCyclicDemand = Filter::max(fabs(demands.roll), fabs(demands.pitch)) / 0.5f;
+                // _proportionalCyclicDemand = Filter::max(fabs(demands.roll), fabs(demands.pitch)) / 0.5f;
                 
                 // When landed, reset integral component of PID
                 if (throttleIsDown) {

--- a/src/pidcontrollers/setpoint.hpp
+++ b/src/pidcontrollers/setpoint.hpp
@@ -106,8 +106,6 @@ namespace hf {
                 {
                     Serial.println(setpoint);
                     velTarget = (setpoint - posActual) * _posP;
-                    Serial.println("velT");
-                    Serial.println(velTarget);
                 }
                 else {
                     float sign = (setpoint - posActual) > 0 ? 1 : -1;

--- a/src/pidcontrollers/setpoint.hpp
+++ b/src/pidcontrollers/setpoint.hpp
@@ -46,7 +46,7 @@ namespace hf {
             
             float THRESHOLD = 0.1;
             // float VERTICAL_VELOCITY = 0.15;
-            float VERTICAL_VELOCITY = 1.0;
+            float VELOCITY = 1.0;
             // Values modified in-flight
             float deltaT;
             float _posTarget;
@@ -104,12 +104,11 @@ namespace hf {
                 float velTarget;
                 if(fabs(setpoint - posActual) < THRESHOLD)
                 {
-                    Serial.println(setpoint);
                     velTarget = (setpoint - posActual) * _posP;
                 }
                 else {
                     float sign = (setpoint - posActual) > 0 ? 1 : -1;
-                    velTarget = VERTICAL_VELOCITY * sign;
+                    velTarget = VELOCITY * sign;
                 }
                 correction = computeCorrection(velTarget, velActual, deltaT);
               
@@ -141,10 +140,10 @@ namespace hf {
                 float velTarget;
                 if(inBandCurr)
                 {
-                  velTarget = (_posTarget - posActual) * _posP;
+                    velTarget = (_posTarget - posActual) * _posP;
                 }
                 else {
-                  velTarget = demand >= 0 ? _m * fabs(demand) + _n : -(_m * fabs(demand) + _n);
+                    velTarget = demand >= 0 ? _m * fabs(demand) + _n : -(_m * fabs(demand) + _n);
                 }
                 
                 correction = computeCorrection(velTarget, velActual, deltaT);

--- a/src/pidcontrollers/setpoint.hpp
+++ b/src/pidcontrollers/setpoint.hpp
@@ -45,7 +45,6 @@ namespace hf {
             float _n;
             
             float THRESHOLD = 0.1;
-            // float VERTICAL_VELOCITY = 0.15;
             float VELOCITY = 1.0;
             // Values modified in-flight
             float deltaT;

--- a/src/pidcontrollers/setpoint.hpp
+++ b/src/pidcontrollers/setpoint.hpp
@@ -45,7 +45,8 @@ namespace hf {
             float _n;
             
             float THRESHOLD = 0.1;
-            float VERTICAL_VELOCITY = 0.15;
+            // float VERTICAL_VELOCITY = 0.15;
+            float VERTICAL_VELOCITY = 1.0;
             // Values modified in-flight
             float deltaT;
             float _posTarget;
@@ -94,24 +95,27 @@ namespace hf {
             bool gotSetpointCorrection(float setpoint, float posActual,
                float velActual, float currentTime, float & correction)
             {
-              // Don't do anything until we have a positive deltaT
-              float deltaT = currentTime - _previousTime;
-              _previousTime = currentTime;
-              if (deltaT == currentTime) return false;
+                // Don't do anything until we have a positive deltaT
+                float deltaT = currentTime - _previousTime;
+                _previousTime = currentTime;
+                if (deltaT == currentTime) return false;
 
-              // compute velocity setpoint
-              float velTarget;
-              if(fabs(setpoint - posActual) < THRESHOLD)
-              {
-                velTarget = (setpoint - posActual) * _posP;
-              }
-              else {
-                float sign = (setpoint - posActual) > 0 ? 1 : -1;
-                velTarget = VERTICAL_VELOCITY * sign;
-              }
-              correction = computeCorrection(velTarget, velActual, deltaT);
+                // compute velocity setpoint
+                float velTarget;
+                if(fabs(setpoint - posActual) < THRESHOLD)
+                {
+                    Serial.println(setpoint);
+                    velTarget = (setpoint - posActual) * _posP;
+                    Serial.println("velT");
+                    Serial.println(velTarget);
+                }
+                else {
+                    float sign = (setpoint - posActual) > 0 ? 1 : -1;
+                    velTarget = VERTICAL_VELOCITY * sign;
+                }
+                correction = computeCorrection(velTarget, velActual, deltaT);
               
-              return true;              
+                return true;              
             }
             
             bool gotManualCorrection(float demand, float posActual, 

--- a/src/pidcontrollers/setpoint.hpp
+++ b/src/pidcontrollers/setpoint.hpp
@@ -96,7 +96,7 @@ namespace hf {
                 _previousTime = currentTime;
                 if (deltaT == currentTime) return false;
 
-                // Reset altitude target if moved into stick deadband
+                // Reset position target if moved into stick deadband
                 bool inBandCurr = inBand(demand);
                 if (inBandCurr && !_inBandPrev) {
                     _posTarget = posActual;
@@ -108,7 +108,7 @@ namespace hf {
                 {
                       resetErrors();
                 }
-                // compute velocity setpoint: inside deadband from altitude error,
+                // compute velocity setpoint: inside deadband from distance error,
                 // outside deadband velocity control
                 float velTarget;
                 if(inBandCurr)

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -245,7 +245,8 @@ namespace hf {
                 // If the action is complete, load the next one
                 if (isActionComplete(_currentAction, state, demands))
                 {
-                  // We've reached the end of the mission
+                  // We've reached the end of the mission, reset executing flag
+                  // and return
                   if (_currentActionIndex == _missionLength)
                   {
                       state.executingMission = false;

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -44,20 +44,6 @@ namespace hf {
             virtual void endOfAction(state_t & state) = 0;
 
         protected:
-            // Set of possible actions
-            static const uint8_t WP_ARM             = 1;
-            static const uint8_t WP_DISARM          = 2;
-            static const uint8_t WP_LAND            = 3;
-            static const uint8_t WP_TAKE_OFF        = 4;
-            static const uint8_t WP_GO_FORWARD      = 5;
-            static const uint8_t WP_GO_BACKWARD     = 6;
-            static const uint8_t WP_GO_LEFT         = 7;
-            static const uint8_t WP_GO_RIGHT        = 8;
-            static const uint8_t WP_CHANGE_ALTITUDE = 9;
-            static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
-            static const uint8_t WP_HOVER           = 11;
-            static const uint8_t WP_TURN_CW         = 12;
-            static const uint8_t WP_TURN_CCW        = 13;
             
             static const uint16_t STACK_LENGTH = 256;
             
@@ -155,6 +141,21 @@ namespace hf {
 
         public:
             
+            // Set of possible actions
+            static const uint8_t WP_ARM             = 1;
+            static const uint8_t WP_DISARM          = 2;
+            static const uint8_t WP_LAND            = 3;
+            static const uint8_t WP_TAKE_OFF        = 4;
+            static const uint8_t WP_GO_FORWARD      = 5;
+            static const uint8_t WP_GO_BACKWARD     = 6;
+            static const uint8_t WP_GO_LEFT         = 7;
+            static const uint8_t WP_GO_RIGHT        = 8;
+            static const uint8_t WP_CHANGE_ALTITUDE = 9;
+            static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
+            static const uint8_t WP_HOVER           = 11;
+            static const uint8_t WP_TURN_CW         = 12;
+            static const uint8_t WP_TURN_CCW        = 13;
+
             void executeAction(state_t & state, demands_t & demands)
             {
                 switch (_currentAction.action) {

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -211,7 +211,33 @@ namespace hf {
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
+                    state.armed = true;
+                    break;                    
+                  }
+                  case WP_DISARM:
+                  {
+                    state.armed = false;
+                    break;
+                  }
+                  case WP_TAKE_OFF:
+                  {
                     
+                    break;
+                  }
+                  case WP_LAND:
+                  {
+
+                    break;                    
+                  }
+                  case WP_CHANGE_ALTITUDE:
+                  {
+                    
+                    break;                    
+                  }
+                  case WP_HOVER:
+                  {
+                    
+                      break;
                   }
                 }
               

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -414,9 +414,9 @@ namespace hf {
                   _startActionTime  = micros();
                   _startActionYaw = state.UAVState->eulerAngles[2];
                   // reset target angles
-                  for(int i=0; i<3, ++i)
+                  for(int i=0; i<3; ++i)
                   {
-                    state.setpointAngle[i] = 0;
+                    demands.setpointAngle[i] = 0;
                   }
                 }
                 

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -198,7 +198,7 @@ namespace hf {
                   }
                   case WP_TAKE_OFF:
                   {
-                      // while taking of deactivate position hold
+                      // while taking off deactivate position hold
                       if ((micros() - _startActionTime)/1000000.0 < TAKEOF_DURATION)
                       {
                           for (int k=0; k < pidCount; k++)

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -413,6 +413,11 @@ namespace hf {
                   // update starting time and yaw
                   _startActionTime  = micros();
                   _startActionYaw = state.UAVState->eulerAngles[2];
+                  // reset target angles
+                  for(int i=0; i<3, ++i)
+                  {
+                    state.setpointAngle[i] = 0;
+                  }
                 }
                 
                 

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -49,7 +49,7 @@ namespace hf {
           static const uint8_t WP_CHANGE_ALTITUDE = 9;
           static const uint8_t WP_HOVER           = 11;
           
-          const float DISTANCE_THRESHOLD = 0.1;
+          const float DISTANCE_THRESHOLD = 0.2;
           
           // Variables used to store the programmed mission
           action_t _mission[256];
@@ -220,14 +220,14 @@ namespace hf {
                     break;
                   }
                   case WP_TAKE_OFF:
-                  {
-                    
-                    break;
-                  }
                   case WP_LAND:
                   {
-
-                    break;                    
+                    // Update setpoint
+                    for (int i=0; i<3; i++)
+                    {
+                      demands.setpoint[i] = _currentAction.position[i];
+                    }
+                    break;
                   }
                   case WP_CHANGE_ALTITUDE:
                   {
@@ -240,7 +240,6 @@ namespace hf {
                       break;
                   }
                 }
-              
               
                 // If the action is complete, load the next one
                 if (isActionComplete(_currentAction, state, demands))

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -67,6 +67,7 @@ namespace hf {
           
           // for actions that involve time
           uint32_t _startActionTime = micros();
+          float _startActionYaw;
           
           // Each action will be linked to a position with respect to the starting
           // point. This position marks where the drone should be at the end of
@@ -154,7 +155,7 @@ namespace hf {
                   action.duration = EEPROM.read(++address);
                   break;
               }
-              case WP_GO_FORWARD:
+              case WP_GO_FORWARD: // For the moment, movement is time based
               {
                 action.action = WP_GO_FORWARD;
                 action.position[0] = _integralPosition[0];
@@ -253,6 +254,43 @@ namespace hf {
                       actionComplete =  (elapsedTime > action.duration);
                       break;
                   }
+                  // We are ot coupling validators here because when changing
+                  // to distance based programing we will need different validators
+                  case WP_GO_FORWARD: // For the moment, movement is time based
+                  {
+                    float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
+                    actionComplete =  (elapsedTime > action.duration);
+                    break;
+                  }
+                  case WP_GO_BACKWARD:
+                  {
+                    float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
+                    actionComplete =  (elapsedTime > action.duration);
+                    break;                    
+                  }
+                  case WP_GO_LEFT:
+                  {
+                    float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
+                    actionComplete =  (elapsedTime > action.duration);
+                    break;                  
+                  }
+                  case WP_GO_RIGHT:
+                  {
+                    float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
+                    actionComplete =  (elapsedTime > action.duration);
+                    break;
+                  }
+                  case WP_TURN_CW: // End yaw smaller than starting yaw 
+                  { 
+                    actionComplete = (state.UAVState->eulerAngles[2] < _startActionYaw - action.rotationDegrees);
+                    break;                                
+                  }
+                  case WP_TURN_CCW: // End yaw bigger than starting yaw
+                  {
+                    actionComplete = (state.UAVState->eulerAngles[2] > _startActionYaw + action.rotationDegrees);
+                    break;                                                
+                  }
+
                 }
                 
                 return actionComplete;
@@ -317,8 +355,9 @@ namespace hf {
                   // Load next action
                   _currentActionIndex += 1;
                   _currentAction = _mission[_currentActionIndex];
-                  // update starting time
+                  // update starting time and angle
                   _startActionTime  = micros();
+                  _startActionYaw = state.UAVState->eulerAngles[2];
                 }
                 
                 

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -170,7 +170,7 @@ namespace hf {
             static const uint8_t WP_TURN_CW         = 12;
             static const uint8_t WP_TURN_CCW        = 13;
 
-            void executeAction(state_t & state, demands_t & demands)
+            void executeAction(state_t & state, demands_t & demands, bool safeToArm)
             {
                 if (_actionStart)
                 {
@@ -184,7 +184,8 @@ namespace hf {
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
-                    state.armed = true;
+                    if (safeToArm)
+                        state.armed = true;
                     break;                    
                   }
                   case WP_DISARM:

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -205,14 +205,12 @@ namespace hf {
                           {
                               if (controllers[k]->getPIDType() == POSHOLD) controllers[k]->deactivate();
                           }
-                          state.takingOff = true;
                       }
                       else {
                           for (int k=0; k < pidCount; k++)
                           {
                               if (controllers[k]->getPIDType() == POSHOLD) controllers[k]->activate();
                           }
-                          state.takingOff = false;
                       }
                       // Update setpoint
                       for (int i=0; i<3; i++)

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -332,14 +332,45 @@ namespace hf {
                   }
                   case WP_CHANGE_ALTITUDE:
                   {
-                    
-                    break;                    
+                      break;                    
                   }
                   case WP_HOVER:
                   {
-                    
                       break;
                   }
+                  // We are ot coupling validators here because when changing
+                  // to distance based programing we will need different validators
+                  case WP_GO_FORWARD: // For the moment, movement is time based
+                  {
+                      // Set level pitch
+                      break;
+                  }
+                  case WP_GO_BACKWARD:
+                  {
+                      // Set level pitch
+                      break;                    
+                  }
+                  case WP_GO_LEFT:
+                  {
+                      // Set level roll
+                      break;                  
+                  }
+                  case WP_GO_RIGHT:
+                  {
+                      // Set level roll
+                      break;
+                  }
+                  case WP_TURN_CW: // End yaw smaller than starting yaw 
+                  { 
+                      // Set rate yaw
+                      break;                                
+                  }
+                  case WP_TURN_CCW: // End yaw bigger than starting yaw
+                  {
+                      // Set rate yaw
+                      break;                                                
+                  }
+                  
                 }
               
                 // If the action is complete, load the next one

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -59,6 +59,8 @@ namespace hf {
             static const uint8_t WP_TURN_CW         = 12;
             static const uint8_t WP_TURN_CCW        = 13;
             
+            static const uint16_t STACK_LENGTH = 256;
+            
             // Required constants and values
             const float DISTANCE_THRESHOLD = 0.2;
             // To achieve desired movement (F/B, L/R and rotations)

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -198,7 +198,7 @@ namespace hf {
                   }
                   case WP_TAKE_OFF:
                   {
-                      // if first stage set high throttle by setting take off flag
+                      // while taking of deactivate position hold
                       if ((micros() - _startActionTime)/1000000.0 < TAKEOF_DURATION)
                       {
                           for (int k=0; k < pidCount; k++)

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <EEPROM.h>
+#include "datatypes.hpp"
 
 namespace hf {
 
@@ -171,7 +172,8 @@ namespace hf {
             static const uint8_t WP_TURN_CW         = 12;
             static const uint8_t WP_TURN_CCW        = 13;
 
-            void executeAction(state_t & state, demands_t & demands, bool safeToArm)
+            void executeAction(state_t & state, demands_t & demands, bool safeToArm,
+               PID_Controller * controllers[256], uint8_t pidCount)
             {
                 if (_actionStart)
                 {
@@ -199,9 +201,17 @@ namespace hf {
                       // if first stage set high throttle by setting take off flag
                       if ((micros() - _startActionTime)/1000000.0 < TAKEOF_DURATION)
                       {
+                          for (int k=0; k < pidCount; k++)
+                          {
+                              if (controllers[k]->getPIDType() == POSHOLD) controllers[k]->deactivate();
+                          }
                           state.takingOff = true;
                       }
                       else {
+                          for (int k=0; k < pidCount; k++)
+                          {
+                              if (controllers[k]->getPIDType() == POSHOLD) controllers[k]->activate();
+                          }
                           state.takingOff = false;
                       }
                       // Update setpoint

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -59,7 +59,13 @@ namespace hf {
           static const uint8_t WP_TURN_CW         = 12;
           static const uint8_t WP_TURN_CCW        = 13;
           
+          // Required constants and values
           const float DISTANCE_THRESHOLD = 0.2;
+          // To achieve desired movement (F/B, L/R and rotations)
+          // XXX Must be tuned
+          const float TARGET_ROLL        = 5;
+          const float TARGET_PITCH       = 5; // angle in degrees
+          const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
           
           // Variables used to store the programmed mission
           action_t _mission[256];
@@ -355,25 +361,25 @@ namespace hf {
                   case WP_GO_FORWARD: // For the moment, movement is time based
                   {
                       Serial.println("Go forward");
-                      // Set level pitch
+                      demands.setpointAngle[0] = -TARGET_PITCH;
                       break;
                   }
                   case WP_GO_BACKWARD:
                   {
                       Serial.println("Go backward");
-                      // Set level pitch
+                      demands.setpointAngle[0] = TARGET_PITCH;
                       break;                    
                   }
                   case WP_GO_LEFT:
                   {
                       Serial.println("Go Left");
-                      // Set level roll
+                      demands.setpointAngle[1] = -TARGET_ROLL;
                       break;                  
                   }
                   case WP_GO_RIGHT:
                   {
                       Serial.println("Go right");
-                      // Set level roll
+                      demands.setpointAngle[1] = TARGET_ROLL;
                       break;
                   }
                   case WP_TURN_CW: // End yaw smaller than starting yaw 

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -385,13 +385,13 @@ namespace hf {
                   case WP_TURN_CW: // End yaw smaller than starting yaw 
                   { 
                       Serial.println("Turn CW");
-                      // Set rate yaw
+                      demads.setpointRate[2] = -TARGET_YAW_RATE;
                       break;                                
                   }
                   case WP_TURN_CCW: // End yaw bigger than starting yaw
                   {
                       Serial.println("Turn CCW");
-                      // Set rate yaw
+                      demads.setpointRate[2] = TARGET_YAW_RATE;
                       break;                                                
                   }
                   
@@ -404,6 +404,7 @@ namespace hf {
                   // and return
                   if (_currentActionIndex == _missionLength - 1)
                   {
+                      Serial.println("Mission END");
                       state.executingMission = false;
                       return;
                   }
@@ -413,10 +414,11 @@ namespace hf {
                   // update starting time and yaw
                   _startActionTime  = micros();
                   _startActionYaw = state.UAVState->eulerAngles[2];
-                  // reset target angles
+                  // reset target angles and rates
                   for(int i=0; i<3; ++i)
                   {
                     demands.setpointAngle[i] = 0;
+                    demands.setpointRate[i] = 0;
                   }
                 }
                 

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -24,6 +24,9 @@
 
 namespace hf {
 
+    // XXX It can be a good idea to create an Action class that is in charge 
+    // of validating himself (and maybe executing?) so that validation and 
+    // creation code can be delegated there
     typedef struct {
 
       uint8_t action;
@@ -254,7 +257,7 @@ namespace hf {
                       actionComplete =  (elapsedTime > action.duration);
                       break;
                   }
-                  // We are ot coupling validators here because when changing
+                  // We are not coupling validators here because when changing
                   // to distance based programing we will need different validators
                   case WP_GO_FORWARD: // For the moment, movement is time based
                   {
@@ -386,7 +389,7 @@ namespace hf {
                   // Load next action
                   _currentActionIndex += 1;
                   _currentAction = _mission[_currentActionIndex];
-                  // update starting time and angle
+                  // update starting time and yaw
                   _startActionTime  = micros();
                   _startActionYaw = state.UAVState->eulerAngles[2];
                 }

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -52,9 +52,9 @@ namespace hf {
             // To achieve desired movement (F/B, L/R and rotations)
             // XXX Must be tuned
             const float TARGET_ROLL        = 5;
-            const float TARGET_PITCH       = 5; // angle in degrees
-            const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
-            const float TAKEOF_DURATION    = 1.00; // takeof first stage duration in s XXX to be tuned
+            const float TARGET_PITCH       = 5;     // angle in degrees
+            const float TARGET_YAW_RATE    = 2;     // angular velocity in degrees per second
+            const float TAKEOF_DURATION    = 1.00;  // takeof first stage duration in s XXX to be tuned
             
             const float MAX_HEIGHT         = 3;
           

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -319,24 +319,20 @@ namespace hf {
             void executeAction(state_t & state, demands_t & demands)
             {
                 // XXX Remove prints for oficial release
-                Serial.println("Executing action:");
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
-                    Serial.println("Arm");
                     state.armed = true;
                     break;                    
                   }
                   case WP_DISARM:
                   {
-                    Serial.println("Disarm");
                     state.armed = false;
                     break;
                   }
                   case WP_TAKE_OFF:
                   case WP_LAND:
                   {
-                    _currentAction.action == WP_TAKE_OFF ? Serial.println("Take off") : Serial.println("Land");
                     // Update setpoint
                     for (int i=0; i<3; i++)
                     {
@@ -346,50 +342,42 @@ namespace hf {
                   }
                   case WP_CHANGE_ALTITUDE:
                   {
-                      Serial.println("Change altitude");
                       demands.setpoint[2] = _currentAction.position[2];
                       break;                    
                   }
                   case WP_HOVER:
                   {
-                      Serial.println("Hover");
                       break;
                   }
                   // We are ot coupling validators here because when changing
                   // to distance based programing we will need different validators
                   case WP_GO_FORWARD: // For the moment, movement is time based
                   {
-                      Serial.println("Go forward");
                       demands.setpointAngle[0] = -TARGET_PITCH;
                       break;
                   }
                   case WP_GO_BACKWARD:
                   {
-                      Serial.println("Go backward");
                       demands.setpointAngle[0] = TARGET_PITCH;
                       break;                    
                   }
                   case WP_GO_LEFT:
                   {
-                      Serial.println("Go Left");
                       demands.setpointAngle[1] = -TARGET_ROLL;
                       break;                  
                   }
                   case WP_GO_RIGHT:
                   {
-                      Serial.println("Go right");
                       demands.setpointAngle[1] = TARGET_ROLL;
                       break;
                   }
                   case WP_TURN_CW: // End yaw smaller than starting yaw 
                   { 
-                      Serial.println("Turn CW");
                       demands.setpointRate[2] = -TARGET_YAW_RATE;
                       break;                                
                   }
                   case WP_TURN_CCW: // End yaw bigger than starting yaw
                   {
-                      Serial.println("Turn CCW");
                       demands.setpointRate[2] = TARGET_YAW_RATE;
                       break;                                                
                   }
@@ -404,7 +392,6 @@ namespace hf {
                   // and return
                   if (_currentActionIndex == _missionLength - 1)
                   {
-                      Serial.println("Mission END");
                       state.executingMission = false;
                       // Reset action pointer to enable mission execution again
                       _currentActionIndex = 0;

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -237,8 +237,6 @@ namespace hf {
                   {
                       break;
                   }
-                  // We are ot coupling validators here because when changing
-                  // to distance based programing we will need different validators
                   case WP_GO_FORWARD: // For the moment, movement is time based
                   {
                       demands.setpointAngle[0] = -TARGET_PITCH;

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -54,6 +54,8 @@ namespace hf {
             const float TARGET_ROLL        = 5;
             const float TARGET_PITCH       = 5; // angle in degrees
             const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
+            
+            const float MAX_HEIGHT         = 3;
           
             // for actions that involve time
             bool _actionStart = true;
@@ -164,6 +166,9 @@ namespace hf {
                     _actionStart = false; 
                     _startActionTime = micros();
                     _startActionYaw = state.UAVState->eulerAngles[2];
+                    // Limit maximum height of the actions
+                    if (_currentAction.position[2] > MAX_HEIGHT)
+                        _currentAction.position[2] = MAX_HEIGHT;
                 } 
                 switch (_currentAction.action) {
                   case WP_ARM:

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -303,9 +303,7 @@ namespace hf {
                   }
 
                 }
-                
                 return actionComplete;
-
             }
 
         public:
@@ -421,8 +419,6 @@ namespace hf {
                     demands.setpointRate[i] = 0;
                   }
                 }
-                
-                
             }
 
             // XXX only for debuging purposes

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -54,6 +54,7 @@ namespace hf {
             const float TARGET_ROLL        = 5;
             const float TARGET_PITCH       = 5; // angle in degrees
             const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
+            const float TAKEOF_DURATION    = 1.00; // takeof first stage duration in s XXX to be tuned
             
             const float MAX_HEIGHT         = 3;
           
@@ -184,16 +185,32 @@ namespace hf {
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
-                    if (safeToArm)
-                        state.armed = true;
-                    break;                    
+                      if (safeToArm)
+                          state.armed = true;
+                      break;                    
                   }
                   case WP_DISARM:
                   {
-                    state.armed = false;
-                    break;
+                      state.armed = false;
+                      break;
                   }
                   case WP_TAKE_OFF:
+                  {
+                      // if first stage set high throttle by setting take off flag
+                      if ((micros() - _startActionTime)/1000000.0 < TAKEOF_DURATION)
+                      {
+                          state.takingOff = true;
+                      }
+                      else {
+                          state.takingOff = false;
+                      }
+                      // Update setpoint
+                      for (int i=0; i<3; i++)
+                      {
+                          demands.setpoint[i] = _currentAction.position[i];
+                      }
+                      break;                    
+                  }
                   case WP_LAND:
                   {
                     // Update setpoint

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -46,8 +46,15 @@ namespace hf {
           static const uint8_t WP_DISARM          = 2;
           static const uint8_t WP_LAND            = 3;
           static const uint8_t WP_TAKE_OFF        = 4;
+          static const uint8_t WP_GO_FORWARD      = 5;
+          static const uint8_t WP_GO_BACKWARD     = 6;
+          static const uint8_t WP_GO_LEFT         = 7;
+          static const uint8_t WP_GO_RIGHT        = 8;
           static const uint8_t WP_CHANGE_ALTITUDE = 9;
+          static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
           static const uint8_t WP_HOVER           = 11;
+          static const uint8_t WP_TURN_CW         = 12;
+          static const uint8_t WP_TURN_CCW        = 13;
           
           const float DISTANCE_THRESHOLD = 0.2;
           
@@ -146,6 +153,62 @@ namespace hf {
                   action.position[2] = _integralPosition[2];
                   action.duration = EEPROM.read(++address);
                   break;
+              }
+              case WP_GO_FORWARD:
+              {
+                action.action = WP_GO_FORWARD;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.duration = EEPROM.read(++address);
+                break;
+              }
+              case WP_GO_BACKWARD:
+              {
+                action.action = WP_GO_BACKWARD;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.duration = EEPROM.read(++address);
+                break;                
+              }
+              case WP_GO_LEFT:
+              {
+                action.action = WP_GO_LEFT;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.duration = EEPROM.read(++address);
+                break;                
+              }
+              case WP_GO_RIGHT:
+              {
+                action.action = WP_GO_RIGHT;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.duration = EEPROM.read(++address);
+                break;                
+              }
+              case WP_TURN_CW:
+              {
+                action.action = WP_TURN_CW;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.rotationDegrees = EEPROM.read(++address);
+                action.clockwise = true;
+                break;                                
+              }
+              case WP_TURN_CCW:
+              {
+                action.action = WP_TURN_CCW;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.rotationDegrees = EEPROM.read(++address);
+                action.clockwise = false;
+                break;                                                
               }
             }
             mission[actionIndex] = action;

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -112,7 +112,7 @@ namespace hf {
           int addActionToMission(uint8_t value, action_t mission[256],
                                  int actionIndex, int address)
           {
-            action_t action;
+            action_t action = {};
             switch (value) {
               
               case WP_ARM:
@@ -130,7 +130,8 @@ namespace hf {
                   action.action = WP_TAKE_OFF;
                   action.position[0] = _integralPosition[0];
                   action.position[1] = _integralPosition[1];
-                  action.position[2] = EEPROM.read(++address);
+                  _integralPosition[2] = EEPROM.read(++address);
+                  action.position[2] = _integralPosition[2];
                   break;
               }
               case WP_LAND:
@@ -146,7 +147,8 @@ namespace hf {
                   action.action = WP_CHANGE_ALTITUDE;
                   action.position[0] = _integralPosition[0];
                   action.position[1] = _integralPosition[1];
-                  action.position[2] = EEPROM.read(++address);
+                  _integralPosition[2] = EEPROM.read(++address); 
+                  action.position[2] = _integralPosition[2];
                   break;
               }
               case WP_HOVER:
@@ -312,20 +314,24 @@ namespace hf {
             
             void executeAction(state_t & state, demands_t & demands)
             {
+                Serial.println("Executing action:");
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
+                    Serial.println("Arm");
                     state.armed = true;
                     break;                    
                   }
                   case WP_DISARM:
                   {
+                    Serial.println("Disarm");
                     state.armed = false;
                     break;
                   }
                   case WP_TAKE_OFF:
                   case WP_LAND:
                   {
+                    _currentAction.action == WP_TAKE_OFF ? Serial.println("Take off") : Serial.println("Land");
                     // Update setpoint
                     for (int i=0; i<3; i++)
                     {
@@ -335,41 +341,50 @@ namespace hf {
                   }
                   case WP_CHANGE_ALTITUDE:
                   {
+                      Serial.println("Change altitude");
+                      demands.setpoint[2] = _currentAction.position[2];
                       break;                    
                   }
                   case WP_HOVER:
                   {
+                      Serial.println("Hover");
                       break;
                   }
                   // We are ot coupling validators here because when changing
                   // to distance based programing we will need different validators
                   case WP_GO_FORWARD: // For the moment, movement is time based
                   {
+                      Serial.println("Go forward");
                       // Set level pitch
                       break;
                   }
                   case WP_GO_BACKWARD:
                   {
+                      Serial.println("Go backward");
                       // Set level pitch
                       break;                    
                   }
                   case WP_GO_LEFT:
                   {
+                      Serial.println("Go Left");
                       // Set level roll
                       break;                  
                   }
                   case WP_GO_RIGHT:
                   {
+                      Serial.println("Go right");
                       // Set level roll
                       break;
                   }
                   case WP_TURN_CW: // End yaw smaller than starting yaw 
                   { 
+                      Serial.println("Turn CW");
                       // Set rate yaw
                       break;                                
                   }
                   case WP_TURN_CCW: // End yaw bigger than starting yaw
                   {
+                      Serial.println("Turn CCW");
                       // Set rate yaw
                       break;                                                
                   }
@@ -381,7 +396,7 @@ namespace hf {
                 {
                   // We've reached the end of the mission, reset executing flag
                   // and return
-                  if (_currentActionIndex == _missionLength)
+                  if (_currentActionIndex == _missionLength - 1)
                   {
                       state.executingMission = false;
                       return;

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -37,197 +37,42 @@ namespace hf {
 
     } action_t;
 
-
     class Planner {
         
         private:
-          
-          bool _hasMission;
-          
-          // Set of possible actions
-          static const uint8_t WP_ARM             = 1;
-          static const uint8_t WP_DISARM          = 2;
-          static const uint8_t WP_LAND            = 3;
-          static const uint8_t WP_TAKE_OFF        = 4;
-          static const uint8_t WP_GO_FORWARD      = 5;
-          static const uint8_t WP_GO_BACKWARD     = 6;
-          static const uint8_t WP_GO_LEFT         = 7;
-          static const uint8_t WP_GO_RIGHT        = 8;
-          static const uint8_t WP_CHANGE_ALTITUDE = 9;
-          static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
-          static const uint8_t WP_HOVER           = 11;
-          static const uint8_t WP_TURN_CW         = 12;
-          static const uint8_t WP_TURN_CCW        = 13;
-          
-          // Required constants and values
-          const float DISTANCE_THRESHOLD = 0.2;
-          // To achieve desired movement (F/B, L/R and rotations)
-          // XXX Must be tuned
-          const float TARGET_ROLL        = 5;
-          const float TARGET_PITCH       = 5; // angle in degrees
-          const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
-          
-          // Variables used to store the programmed mission
-          action_t _mission[256];
-          uint8_t _currentActionIndex = 0;
-          action_t _currentAction;
-          // mission length
-          uint8_t _missionLength = 0;
-          
-          // for actions that involve time
-          uint32_t _startActionTime = micros();
-          float _startActionYaw;
-          
-          // Each action will be linked to a position with respect to the starting
-          // point. This position marks where the drone should be at the end of
-          // the action and takes in to account the position of the previous action 
-          float _integralPosition[3] = {0, 0, 0};
-                        
-          void loadMission(action_t mission[256], int startingAddress)
-          {
-              int address = startingAddress;
-              int actionIndex = 0;
-              int EEPROMlength = EEPROM.length();
-              // Although we iterate through the whole EEPROM length the index
-              // that tells which address to read is the value of the variable 
-              // address. Some actions, such as hover, have a value (duration 
-              // in this case) linked to them and when this happens we read both
-              // action ( EEPROM index i) and value (EEPROM index i+1) in the
-              // same iteration. We loop through the whole EEPROM length because
-              // it is the maximum number of iterations in the worst case scenario.
-              for (int ii = 0; ii < EEPROMlength; ii++)
-              {
-                // read a byte from the current address of the EEPROM
-                uint8_t value = EEPROM.read(address);
-                // There is no action with code 0, so if a 0 is read we can
-                // safely say that the mission is already loaded and stop reading 
-                if (value == 0 || value == 255) {
-                  break;
-                }
-                int newAddress = addActionToMission(value, mission, actionIndex, address);
-                actionIndex += 1;
-                address = newAddress + 1;
-                // If we reach this point is because at least one instruction
-                // has been loaded
-                _hasMission = true;
-                // update mission length
-                _missionLength += 1;
-              }
-          } // loadMission
-          
-          int addActionToMission(uint8_t value, action_t mission[256],
-                                 int actionIndex, int address)
-          {
-            action_t action = {};
-            switch (value) {
-              
-              case WP_ARM:
-              {
-                  action.action = WP_ARM;
-                  break;
-              }
-              case WP_DISARM:
-              {
-                  action.action = WP_DISARM;
-                  break;
-              }
-              case WP_TAKE_OFF:
-              {
-                  action.action = WP_TAKE_OFF;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  _integralPosition[2] = EEPROM.read(++address);
-                  action.position[2] = _integralPosition[2];
-                  break;
-              }
-              case WP_LAND:
-              {
-                  action.action = WP_LAND;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  action.position[2] = 0;
-                  break;
-              }
-              case WP_CHANGE_ALTITUDE:
-              {
-                  action.action = WP_CHANGE_ALTITUDE;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  _integralPosition[2] = EEPROM.read(++address); 
-                  action.position[2] = _integralPosition[2];
-                  break;
-              }
-              case WP_HOVER:
-              {
-                  action.action = WP_HOVER;
-                  action.position[0] = _integralPosition[0];
-                  action.position[1] = _integralPosition[1];
-                  action.position[2] = _integralPosition[2];
-                  action.duration = EEPROM.read(++address);
-                  break;
-              }
-              case WP_GO_FORWARD: // For the moment, movement is time based
-              {
-                action.action = WP_GO_FORWARD;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;
-              }
-              case WP_GO_BACKWARD:
-              {
-                action.action = WP_GO_BACKWARD;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;                
-              }
-              case WP_GO_LEFT:
-              {
-                action.action = WP_GO_LEFT;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;                
-              }
-              case WP_GO_RIGHT:
-              {
-                action.action = WP_GO_RIGHT;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.duration = EEPROM.read(++address);
-                break;                
-              }
-              case WP_TURN_CW:
-              {
-                action.action = WP_TURN_CW;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.rotationDegrees = EEPROM.read(++address);
-                action.clockwise = true;
-                break;                                
-              }
-              case WP_TURN_CCW:
-              {
-                action.action = WP_TURN_CCW;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
-                action.position[2] = _integralPosition[2];
-                action.rotationDegrees = EEPROM.read(++address);
-                action.clockwise = false;
-                break;                                                
-              }
-            }
-            mission[actionIndex] = action;
-            return address;
-          } // buildAction
+                      
+            virtual void endOfAction(state_t & state) = 0;
 
         protected:
+            // Set of possible actions
+            static const uint8_t WP_ARM             = 1;
+            static const uint8_t WP_DISARM          = 2;
+            static const uint8_t WP_LAND            = 3;
+            static const uint8_t WP_TAKE_OFF        = 4;
+            static const uint8_t WP_GO_FORWARD      = 5;
+            static const uint8_t WP_GO_BACKWARD     = 6;
+            static const uint8_t WP_GO_LEFT         = 7;
+            static const uint8_t WP_GO_RIGHT        = 8;
+            static const uint8_t WP_CHANGE_ALTITUDE = 9;
+            static const uint8_t WP_CHANGE_SPEED    = 10; // XXX To be implemented
+            static const uint8_t WP_HOVER           = 11;
+            static const uint8_t WP_TURN_CW         = 12;
+            static const uint8_t WP_TURN_CCW        = 13;
+            
+            // Required constants and values
+            const float DISTANCE_THRESHOLD = 0.2;
+            // To achieve desired movement (F/B, L/R and rotations)
+            // XXX Must be tuned
+            const float TARGET_ROLL        = 5;
+            const float TARGET_PITCH       = 5; // angle in degrees
+            const float TARGET_YAW_RATE    = 2; // angular velocity in degrees per second
+          
+            // for actions that involve time
+            uint32_t _startActionTime = micros();
+            float _startActionYaw;
+
+            uint8_t _currentActionIndex = 0;
+            action_t _currentAction;
 
             bool isActionComplete(action_t action, state_t & state, demands_t & demands)
             {
@@ -307,18 +152,9 @@ namespace hf {
             }
 
         public:
-
-            void init(int startingAddress)
-            {
-                _hasMission = false;
-                loadMission(_mission, startingAddress);
-                _currentActionIndex = 0;
-                _currentAction = _mission[_currentActionIndex];
-            }
             
             void executeAction(state_t & state, demands_t & demands)
             {
-                // XXX Remove prints for oficial release
                 switch (_currentAction.action) {
                   case WP_ARM:
                   {
@@ -388,19 +224,6 @@ namespace hf {
                 // and rate targets
                 if (isActionComplete(_currentAction, state, demands))
                 {
-                  // We've reached the end of the mission, reset executing flag
-                  // and return
-                  if (_currentActionIndex == _missionLength - 1)
-                  {
-                      state.executingMission = false;
-                      // Reset action pointer to enable mission execution again
-                      _currentActionIndex = 0;
-                      _currentAction = _mission[0];
-                      return;
-                  }
-                  // Load next action
-                  _currentActionIndex += 1;
-                  _currentAction = _mission[_currentActionIndex];
                   // update starting time and yaw
                   _startActionTime  = micros();
                   _startActionYaw = state.UAVState->eulerAngles[2];
@@ -410,36 +233,12 @@ namespace hf {
                     demands.setpointAngle[i] = 0;
                     demands.setpointRate[i] = 0;
                   }
+                  
+                  // This enables us to define planner specific behaviour that
+                  // gets executed when an action is finished
+                  endOfAction(state);
+                  
                 }
-            }
-
-            // XXX only for debuging purposes
-            void printMission(void)
-            {
-                if (!_hasMission)
-                {
-                    return;
-                }
-                for (int i = 0; i<256; i++)
-                {
-                    action_t action = _mission[i];
-                    Serial.print("Action ");
-                    Serial.println(i);
-                    Serial.print("Action Code: ");
-                    Serial.println(action.action);
-                    Serial.print("Position: ");
-                    Serial.print(action.position[0]);
-                    Serial.print(",");
-                    Serial.print(action.position[1]);
-                    Serial.print(",");
-                    Serial.println(action.position[2]);
-                    Serial.print("Rotation: ");
-                    Serial.println(action.rotationDegrees);
-                    Serial.print("Clockwise: ");
-                    Serial.println(action.clockwise);
-                    Serial.print("Duration: ");
-                    Serial.println(action.duration);
-                } 
             }
 
     };  // class Planner

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -30,9 +30,9 @@ namespace hf {
     typedef struct {
 
       uint8_t action;
-      uint8_t position[3];
-      uint8_t rotationDegrees;
-      uint8_t duration;
+      float position[3];
+      float rotationDegrees;
+      float duration;
       bool    clockwise;
 
     } action_t;
@@ -73,17 +73,20 @@ namespace hf {
                 switch (action.action) {
                   case WP_ARM:
                   {
+                      // Serial.println("Arm");
                       actionComplete = state.armed;
                       break;
                   }
                   case WP_DISARM:
                   {
+                      // Serial.println("Disarm");
                       actionComplete = !state.armed;
                       break;
                   }
                   case WP_TAKE_OFF:
                   case WP_CHANGE_ALTITUDE:
                   {
+                      // Serial.println("Takeoff or change alt");
                       if (fabs(action.position[2] - state.UAVState->position[2]) < DISTANCE_THRESHOLD)
                       {
                           actionComplete = true;
@@ -92,11 +95,13 @@ namespace hf {
                   }
                   case WP_LAND:
                   {
+                      // Serial.println("Land");
                       actionComplete = (state.UAVState->position[2] < DISTANCE_THRESHOLD);
                       break;
                   }
                   case WP_HOVER:
                   {
+                      // Serial.println("Hover");
                       float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
                       actionComplete =  (elapsedTime > action.duration);
                       break;
@@ -105,35 +110,41 @@ namespace hf {
                   // to distance based programing we will need different validators
                   case WP_GO_FORWARD: // For the moment, movement is time based
                   {
+                    // Serial.println("Forward");
                     float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
                     actionComplete =  (elapsedTime > action.duration);
                     break;
                   }
                   case WP_GO_BACKWARD:
                   {
+                    // Serial.println("Back");
                     float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
                     actionComplete =  (elapsedTime > action.duration);
                     break;                    
                   }
                   case WP_GO_LEFT:
                   {
+                    // Serial.println("Left");
                     float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
                     actionComplete =  (elapsedTime > action.duration);
                     break;                  
                   }
                   case WP_GO_RIGHT:
                   {
+                    // Serial.println("Right");
                     float elapsedTime = (micros() - _startActionTime) / 1000000.0f;
                     actionComplete =  (elapsedTime > action.duration);
                     break;
                   }
                   case WP_TURN_CW: // End yaw smaller than starting yaw 
                   { 
+                    // Serial.println("Turn CW");
                     actionComplete = (state.UAVState->eulerAngles[2] < _startActionYaw - action.rotationDegrees);
                     break;                                
                   }
                   case WP_TURN_CCW: // End yaw bigger than starting yaw
                   {
+                    // Serial.println("Turn CCW");
                     actionComplete = (state.UAVState->eulerAngles[2] > _startActionYaw + action.rotationDegrees);
                     break;                                                
                   }

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -318,6 +318,7 @@ namespace hf {
             
             void executeAction(state_t & state, demands_t & demands)
             {
+                // XXX Remove prints for oficial release
                 Serial.println("Executing action:");
                 switch (_currentAction.action) {
                   case WP_ARM:
@@ -395,7 +396,8 @@ namespace hf {
                   
                 }
               
-                // If the action is complete, load the next one
+                // If the action is complete, load the next one and reset angle
+                // and rate targets
                 if (isActionComplete(_currentAction, state, demands))
                 {
                   // We've reached the end of the mission, reset executing flag
@@ -404,6 +406,9 @@ namespace hf {
                   {
                       Serial.println("Mission END");
                       state.executingMission = false;
+                      // Reset action pointer to enable mission execution again
+                      _currentActionIndex = 0;
+                      _currentAction = _mission[0];
                       return;
                   }
                   // Load next action

--- a/src/planner.hpp
+++ b/src/planner.hpp
@@ -385,13 +385,13 @@ namespace hf {
                   case WP_TURN_CW: // End yaw smaller than starting yaw 
                   { 
                       Serial.println("Turn CW");
-                      demads.setpointRate[2] = -TARGET_YAW_RATE;
+                      demands.setpointRate[2] = -TARGET_YAW_RATE;
                       break;                                
                   }
                   case WP_TURN_CCW: // End yaw bigger than starting yaw
                   {
                       Serial.println("Turn CCW");
-                      demads.setpointRate[2] = TARGET_YAW_RATE;
+                      demands.setpointRate[2] = TARGET_YAW_RATE;
                       break;                                                
                   }
                   

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -146,7 +146,7 @@
           _stack[_stackIndex] = action;
           _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
           _actionsInStack += 1;
-        } // buildAction
+        } // addActionToStack
 
         virtual void endOfAction(state_t & state) override
         {
@@ -160,7 +160,7 @@
             } else {
                 state.executingStack = false;
             }
-        }
+        } // endOfAction
     
     public:
       

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -90,32 +90,32 @@
             case WP_TAKE_OFF:
             {
                 action.action = WP_TAKE_OFF;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_LAND:
             {
                 action.action = WP_LAND;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = 0;
                 break;
             }
             case WP_CHANGE_ALTITUDE:
             {
                 action.action = WP_CHANGE_ALTITUDE;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_HOVER:
             {
                 action.action = WP_HOVER;
-                action.position[0] = 0;
-                action.position[1] = 0;
+                // action.position[0] = 0;
+                // action.position[1] = 0;
                 action.position[2] = 0;
                 action.duration = data;
                 break;
@@ -123,8 +123,8 @@
             case WP_GO_FORWARD: // For the moment, movement is time based
             {
               action.action = WP_GO_FORWARD;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;
@@ -132,8 +132,8 @@
             case WP_GO_BACKWARD:
             {
               action.action = WP_GO_BACKWARD;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;                
@@ -141,8 +141,8 @@
             case WP_GO_LEFT:
             {
               action.action = WP_GO_LEFT;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;                
@@ -150,8 +150,8 @@
             case WP_GO_RIGHT:
             {
               action.action = WP_GO_RIGHT;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.duration = data;
               break;                
@@ -159,8 +159,8 @@
             case WP_TURN_CW:
             {
               action.action = WP_TURN_CW;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = true;
@@ -169,8 +169,8 @@
             case WP_TURN_CCW:
             {
               action.action = WP_TURN_CCW;
-              action.position[0] = 0;
-              action.position[1] = 0;
+              // action.position[0] = 0;
+              // action.position[1] = 0;
               action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = false;

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -72,7 +72,7 @@
           _actionStart = true;
         }
         
-        void addActionToStack(state_t & state, uint8_t actionCode, int data)
+        void addActionToStack(state_t & state, uint8_t actionCode, float data)
         {
           action_t action = {};
           switch (actionCode) {

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -38,7 +38,7 @@
         // // the action and takes in to account the position of the previous action 
         // float _integralPosition[3] = {0, 0, 0};
 
-        virtual void endOfAction(state_t & state) override
+        virtual void endOfAction(state_t & state, demands_t & demands) override
         {
             _actionsInStack -= 1;
             // Update index from where to grab the next action
@@ -64,6 +64,7 @@
           _currentActionIndex = 0;
           _stackIndex = 0;
           _actionsInStack = 0;
+          _actionStart = true;
         }
         
         void addActionToStack(state_t & state, uint8_t actionCode, int data)
@@ -174,6 +175,7 @@
           _stack[_stackIndex] = action;
           _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
           _actionsInStack += 1;
+          _currentAction = _stack[_currentActionIndex];
         } // addActionToStack
         
       

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -38,6 +38,34 @@
         // // the action and takes in to account the position of the previous action 
         // float _integralPosition[3] = {0, 0, 0};
 
+        virtual void endOfAction(state_t & state) override
+        {
+            _actionsInStack -= 1;
+            // Update index from where to grab the next action
+            _currentActionIndex = (_currentActionIndex + 1) % STACK_LENGTH;
+            // If there are still actions to be performed load the next one
+            if (_actionsInStack > 0)
+            {
+                _currentAction = _stack[_currentActionIndex];
+            } else {
+                state.executingStack = false;
+            }
+        } // endOfAction
+    
+    public:
+      
+        void init()
+        {
+            reset();
+        }
+
+        void reset()
+        {
+          _currentActionIndex = 0;
+          _stackIndex = 0;
+          _actionsInStack = 0;
+        }
+        
         void addActionToStack(state_t & state, uint8_t actionCode, int data)
         {
           action_t action = {};
@@ -147,34 +175,7 @@
           _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
           _actionsInStack += 1;
         } // addActionToStack
-
-        virtual void endOfAction(state_t & state) override
-        {
-            _actionsInStack -= 1;
-            // Update index from where to grab the next action
-            _currentActionIndex = (_currentActionIndex + 1) % STACK_LENGTH;
-            // If there are still actions to be performed load the next one
-            if (_actionsInStack > 0)
-            {
-                _currentAction = _stack[_currentActionIndex];
-            } else {
-                state.executingStack = false;
-            }
-        } // endOfAction
-    
-    public:
-      
-        void init()
-        {
-            reset();
-        }
-
-        void reset()
-        {
-          _currentActionIndex = 0;
-          _stackIndex = 0;
-          _actionsInStack = 0;
-        }
+        
       
     }; // class IndividualPlanner
 

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -47,6 +47,11 @@
             if (_actionsInStack > 0)
             {
                 _currentAction = _stack[_currentActionIndex];
+                // Set target height as the end height of the previous action
+                // except for land action
+                _currentAction.position[2] = _currentAction.position[2] == 0 ? state.UAVState->position[0] : _currentAction.position[2];
+                if (_currentAction.action == WP_LAND) _currentAction.position[2] = 0;
+                
             } else {
                 state.executingStack = false;
             }
@@ -85,78 +90,78 @@
             case WP_TAKE_OFF:
             {
                 action.action = WP_TAKE_OFF;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
+                action.position[0] = 0;
+                action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_LAND:
             {
                 action.action = WP_LAND;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
+                action.position[0] = 0;
+                action.position[1] = 0;
                 action.position[2] = 0;
                 break;
             }
             case WP_CHANGE_ALTITUDE:
             {
                 action.action = WP_CHANGE_ALTITUDE;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
+                action.position[0] = 0;
+                action.position[1] = 0;
                 action.position[2] = data;
                 break;
             }
             case WP_HOVER:
             {
                 action.action = WP_HOVER;
-                action.position[0] = state.UAVState->position[0];
-                action.position[1] = state.UAVState->position[1];
-                action.position[2] = state.UAVState->position[2];
+                action.position[0] = 0;
+                action.position[1] = 0;
+                action.position[2] = 0;
                 action.duration = data;
                 break;
             }
             case WP_GO_FORWARD: // For the moment, movement is time based
             {
               action.action = WP_GO_FORWARD;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;
             }
             case WP_GO_BACKWARD:
             {
               action.action = WP_GO_BACKWARD;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;                
             }
             case WP_GO_LEFT:
             {
               action.action = WP_GO_LEFT;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;                
             }
             case WP_GO_RIGHT:
             {
               action.action = WP_GO_RIGHT;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.duration = data;
               break;                
             }
             case WP_TURN_CW:
             {
               action.action = WP_TURN_CW;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = true;
               break;                                
@@ -164,9 +169,9 @@
             case WP_TURN_CCW:
             {
               action.action = WP_TURN_CCW;
-              action.position[0] = state.UAVState->position[0];
-              action.position[1] = state.UAVState->position[1];
-              action.position[2] = state.UAVState->position[2];
+              action.position[0] = 0;
+              action.position[1] = 0;
+              action.position[2] = 0;
               action.rotationDegrees = data;
               action.clockwise = false;
               break;                                                

--- a/src/planners/individual.hpp
+++ b/src/planners/individual.hpp
@@ -1,0 +1,181 @@
+/*
+   stack.hpp : Stack planner class that enables inmediate action execution
+
+   Copyright (c) 2018 Juan Gallostra
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #pragma once
+ 
+ #include "planner.hpp"
+ 
+ namespace hf {
+ 
+    class IndividualPlanner : public Planner {
+      
+    private:
+
+        // Variables used to store the actions to be executed
+        action_t _stack[STACK_LENGTH];
+        // stack length
+        uint8_t _actionsInStack = 0; // Number of actions
+        uint8_t _stackIndex = 0;  // Where to add the next action
+        // // Each action will be linked to a position with respect to the starting
+        // // point. This position marks where the drone should be at the end of
+        // // the action and takes in to account the position of the previous action 
+        // float _integralPosition[3] = {0, 0, 0};
+
+        void addActionToStack(state_t & state, uint8_t actionCode, int data)
+        {
+          action_t action = {};
+          switch (actionCode) {
+            
+            case WP_ARM:
+            {
+                action.action = WP_ARM;
+                break;
+            }
+            case WP_DISARM:
+            {
+                action.action = WP_DISARM;
+                break;
+            }
+            case WP_TAKE_OFF:
+            {
+                action.action = WP_TAKE_OFF;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = data;
+                break;
+            }
+            case WP_LAND:
+            {
+                action.action = WP_LAND;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = 0;
+                break;
+            }
+            case WP_CHANGE_ALTITUDE:
+            {
+                action.action = WP_CHANGE_ALTITUDE;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = data;
+                break;
+            }
+            case WP_HOVER:
+            {
+                action.action = WP_HOVER;
+                action.position[0] = state.UAVState->position[0];
+                action.position[1] = state.UAVState->position[1];
+                action.position[2] = state.UAVState->position[2];
+                action.duration = data;
+                break;
+            }
+            case WP_GO_FORWARD: // For the moment, movement is time based
+            {
+              action.action = WP_GO_FORWARD;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;
+            }
+            case WP_GO_BACKWARD:
+            {
+              action.action = WP_GO_BACKWARD;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;                
+            }
+            case WP_GO_LEFT:
+            {
+              action.action = WP_GO_LEFT;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;                
+            }
+            case WP_GO_RIGHT:
+            {
+              action.action = WP_GO_RIGHT;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.duration = data;
+              break;                
+            }
+            case WP_TURN_CW:
+            {
+              action.action = WP_TURN_CW;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.rotationDegrees = data;
+              action.clockwise = true;
+              break;                                
+            }
+            case WP_TURN_CCW:
+            {
+              action.action = WP_TURN_CCW;
+              action.position[0] = state.UAVState->position[0];
+              action.position[1] = state.UAVState->position[1];
+              action.position[2] = state.UAVState->position[2];
+              action.rotationDegrees = data;
+              action.clockwise = false;
+              break;                                                
+            }
+          }
+          _stack[_stackIndex] = action;
+          _stackIndex = (_stackIndex + 1) % STACK_LENGTH;
+          _actionsInStack += 1;
+        } // buildAction
+
+        virtual void endOfAction(state_t & state) override
+        {
+            _actionsInStack -= 1;
+            // Update index from where to grab the next action
+            _currentActionIndex = (_currentActionIndex + 1) % STACK_LENGTH;
+            // If there are still actions to be performed load the next one
+            if (_actionsInStack > 0)
+            {
+                _currentAction = _stack[_currentActionIndex];
+            } else {
+                state.executingStack = false;
+            }
+        }
+    
+    public:
+      
+        void init()
+        {
+            reset();
+        }
+
+        void reset()
+        {
+          _currentActionIndex = 0;
+          _stackIndex = 0;
+          _actionsInStack = 0;
+        }
+      
+    }; // class IndividualPlanner
+
+} // namespace hf

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -206,8 +206,13 @@
         {
               _hasMission = false;
               loadMission(_mission, startingAddress);
-              _currentActionIndex = 0;
-              _currentAction = _mission[_currentActionIndex];
+              reset();
+        }
+        
+        void reset()
+        {
+          _currentActionIndex = 0;
+          _currentAction = _mission[_currentActionIndex];
         }
         
         // XXX only for debuging purposes

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -1,0 +1,243 @@
+/*
+   mission.hpp : Flight mission planner class
+
+   Copyright (c) 2018 Juan Gallostra
+
+   This file is part of Hackflight.
+
+   Hackflight is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Hackflight is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with Hackflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+ #pragma once
+ 
+ #include <EEPROM.h>
+ #include "planner.hpp"
+ 
+ namespace hf {
+ 
+    class MissionPlanner : public Planner {
+      
+    private:
+
+        bool _hasMission;
+        // Variables used to store the programmed mission
+        action_t _mission[256];
+        // mission length
+        uint8_t _missionLength = 0;
+        // Each action will be linked to a position with respect to the starting
+        // point. This position marks where the drone should be at the end of
+        // the action and takes in to account the position of the previous action 
+        float _integralPosition[3] = {0, 0, 0};
+
+        void loadMission(action_t mission[256], int startingAddress)
+        {
+            int address = startingAddress;
+            int actionIndex = 0;
+            int EEPROMlength = EEPROM.length();
+            // Although we iterate through the whole EEPROM length the index
+            // that tells which address to read is the value of the variable 
+            // address. Some actions, such as hover, have a value (duration 
+            // in this case) linked to them and when this happens we read both
+            // action ( EEPROM index i) and value (EEPROM index i+1) in the
+            // same iteration. We loop through the whole EEPROM length because
+            // it is the maximum number of iterations in the worst case scenario.
+            for (int ii = 0; ii < EEPROMlength; ii++)
+            {
+              // read a byte from the current address of the EEPROM
+              uint8_t value = EEPROM.read(address);
+              // There is no action with code 0, so if a 0 is read we can
+              // safely say that the mission is already loaded and stop reading 
+              if (value == 0 || value == 255) {
+                break;
+              }
+              int newAddress = addActionToMission(value, mission, actionIndex, address);
+              actionIndex += 1;
+              address = newAddress + 1;
+              // If we reach this point is because at least one instruction
+              // has been loaded
+              _hasMission = true;
+              // update mission length
+              _missionLength += 1;
+            }
+        } // loadMission
+        
+        int addActionToMission(uint8_t value, action_t mission[256],
+                               int actionIndex, int address)
+        {
+          action_t action = {};
+          switch (value) {
+            
+            case WP_ARM:
+            {
+                action.action = WP_ARM;
+                break;
+            }
+            case WP_DISARM:
+            {
+                action.action = WP_DISARM;
+                break;
+            }
+            case WP_TAKE_OFF:
+            {
+                action.action = WP_TAKE_OFF;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                _integralPosition[2] = EEPROM.read(++address);
+                action.position[2] = _integralPosition[2];
+                break;
+            }
+            case WP_LAND:
+            {
+                action.action = WP_LAND;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = 0;
+                break;
+            }
+            case WP_CHANGE_ALTITUDE:
+            {
+                action.action = WP_CHANGE_ALTITUDE;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                _integralPosition[2] = EEPROM.read(++address); 
+                action.position[2] = _integralPosition[2];
+                break;
+            }
+            case WP_HOVER:
+            {
+                action.action = WP_HOVER;
+                action.position[0] = _integralPosition[0];
+                action.position[1] = _integralPosition[1];
+                action.position[2] = _integralPosition[2];
+                action.duration = EEPROM.read(++address);
+                break;
+            }
+            case WP_GO_FORWARD: // For the moment, movement is time based
+            {
+              action.action = WP_GO_FORWARD;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;
+            }
+            case WP_GO_BACKWARD:
+            {
+              action.action = WP_GO_BACKWARD;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;                
+            }
+            case WP_GO_LEFT:
+            {
+              action.action = WP_GO_LEFT;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;                
+            }
+            case WP_GO_RIGHT:
+            {
+              action.action = WP_GO_RIGHT;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.duration = EEPROM.read(++address);
+              break;                
+            }
+            case WP_TURN_CW:
+            {
+              action.action = WP_TURN_CW;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.rotationDegrees = EEPROM.read(++address);
+              action.clockwise = true;
+              break;                                
+            }
+            case WP_TURN_CCW:
+            {
+              action.action = WP_TURN_CCW;
+              action.position[0] = _integralPosition[0];
+              action.position[1] = _integralPosition[1];
+              action.position[2] = _integralPosition[2];
+              action.rotationDegrees = EEPROM.read(++address);
+              action.clockwise = false;
+              break;                                                
+            }
+          }
+          mission[actionIndex] = action;
+          return address;
+        } // buildAction
+
+        virtual void endOfAction(state_t & state) override
+        {
+          // Load next action
+          _currentActionIndex += 1;
+          _currentAction = _mission[_currentActionIndex];
+          // We've reached the end of the mission, reset executing flag
+          // and return
+          if (_currentActionIndex == _missionLength - 1)
+          {
+              state.executingMission = false;
+              // Reset action pointer to enable mission execution again
+              _currentActionIndex = 0;
+              _currentAction = _mission[0];
+          }
+        }
+    
+    public:
+      
+        void init(int startingAddress)
+        {
+              _hasMission = false;
+              loadMission(_mission, startingAddress);
+              _currentActionIndex = 0;
+              _currentAction = _mission[_currentActionIndex];
+        }
+        
+        // XXX only for debuging purposes
+        void printMission(void)
+        {
+            if (!_hasMission)
+            {
+                return;
+            }
+            for (int i = 0; i<256; i++)
+            {
+                action_t action = _mission[i];
+                Serial.print("Action ");
+                Serial.println(i);
+                Serial.print("Action Code: ");
+                Serial.println(action.action);
+                Serial.print("Position: ");
+                Serial.print(action.position[0]);
+                Serial.print(",");
+                Serial.print(action.position[1]);
+                Serial.print(",");
+                Serial.println(action.position[2]);
+                Serial.print("Rotation: ");
+                Serial.println(action.rotationDegrees);
+                Serial.print("Clockwise: ");
+                Serial.println(action.clockwise);
+                Serial.print("Duration: ");
+                Serial.println(action.duration);
+            } 
+        }      
+      
+    }; // class Mission
+ 
+} // namespace hf

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -183,12 +183,13 @@
           return address;
         } // buildAction
 
-        virtual void endOfAction(state_t & state) override
+        virtual void endOfAction(state_t & state, demands_t & demands) override
         {
           // Load next action
           _currentActionIndex += 1;
           _currentAction = _mission[_currentActionIndex];
-          // We've reached the end of the mission, reset executing flag
+          _startActionYaw = state.UAVState->eulerAngles[2];
+          // If we have reached the end of the mission, reset executing flag
           // and return
           if (_currentActionIndex == _missionLength - 1)
           {

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -31,7 +31,7 @@
 
         bool _hasMission;
         // Variables used to store the programmed mission
-        action_t _mission[256];
+        action_t _mission[STACK_LENGTH];
         // mission length
         uint8_t _missionLength = 0;
         // Each action will be linked to a position with respect to the starting
@@ -39,7 +39,7 @@
         // the action and takes in to account the position of the previous action 
         float _integralPosition[3] = {0, 0, 0};
 
-        void loadMission(action_t mission[256], int startingAddress)
+        void loadMission(action_t mission[STACK_LENGTH], int startingAddress)
         {
             int address = startingAddress;
             int actionIndex = 0;
@@ -71,7 +71,7 @@
             }
         } // loadMission
         
-        int addActionToMission(uint8_t value, action_t mission[256],
+        int addActionToMission(uint8_t value, action_t mission[STACK_LENGTH],
                                int actionIndex, int address)
         {
           action_t action = {};
@@ -216,7 +216,7 @@
             {
                 return;
             }
-            for (int i = 0; i<256; i++)
+            for (int i = 0; i<STACK_LENGTH; i++)
             {
                 action_t action = _mission[i];
                 Serial.print("Action ");

--- a/src/planners/mission.hpp
+++ b/src/planners/mission.hpp
@@ -90,8 +90,8 @@
             case WP_TAKE_OFF:
             {
                 action.action = WP_TAKE_OFF;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 _integralPosition[2] = EEPROM.read(++address);
                 action.position[2] = _integralPosition[2];
                 break;
@@ -99,16 +99,16 @@
             case WP_LAND:
             {
                 action.action = WP_LAND;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 action.position[2] = 0;
                 break;
             }
             case WP_CHANGE_ALTITUDE:
             {
                 action.action = WP_CHANGE_ALTITUDE;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 _integralPosition[2] = EEPROM.read(++address); 
                 action.position[2] = _integralPosition[2];
                 break;
@@ -116,8 +116,8 @@
             case WP_HOVER:
             {
                 action.action = WP_HOVER;
-                action.position[0] = _integralPosition[0];
-                action.position[1] = _integralPosition[1];
+                // action.position[0] = _integralPosition[0];
+                // action.position[1] = _integralPosition[1];
                 action.position[2] = _integralPosition[2];
                 action.duration = EEPROM.read(++address);
                 break;
@@ -125,8 +125,8 @@
             case WP_GO_FORWARD: // For the moment, movement is time based
             {
               action.action = WP_GO_FORWARD;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;
@@ -134,8 +134,8 @@
             case WP_GO_BACKWARD:
             {
               action.action = WP_GO_BACKWARD;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;                
@@ -143,8 +143,8 @@
             case WP_GO_LEFT:
             {
               action.action = WP_GO_LEFT;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;                
@@ -152,8 +152,8 @@
             case WP_GO_RIGHT:
             {
               action.action = WP_GO_RIGHT;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.duration = EEPROM.read(++address);
               break;                
@@ -161,8 +161,8 @@
             case WP_TURN_CW:
             {
               action.action = WP_TURN_CW;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.rotationDegrees = EEPROM.read(++address);
               action.clockwise = true;
@@ -171,8 +171,8 @@
             case WP_TURN_CCW:
             {
               action.action = WP_TURN_CCW;
-              action.position[0] = _integralPosition[0];
-              action.position[1] = _integralPosition[1];
+              // action.position[0] = _integralPosition[0];
+              // action.position[1] = _integralPosition[1];
               action.position[2] = _integralPosition[2];
               action.rotationDegrees = EEPROM.read(++address);
               action.clockwise = false;

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -117,6 +117,7 @@ namespace hf {
         static const uint8_t MAXCHAN = 8;
 
         uint8_t _lastAux1State;
+        uint8_t _lastAux2State;
         uint8_t _aux1State;
         uint8_t _aux2State;
 
@@ -241,6 +242,7 @@ namespace hf {
             
             // Store auxiliary switch state
             _lastAux1State = _aux1State;
+            _lastAux2State = _aux2State;
             _aux1State = getRawval(CHANNEL_AUX1) >= 0.0 ? (getRawval(CHANNEL_AUX1) > .4 ? 2 : 1) : 0;
             _aux2State = getRawval(CHANNEL_AUX2) >= 0.4 ? 1 : 0;
 
@@ -300,6 +302,12 @@ namespace hf {
         {
            return (_lastAux1State != _aux1State);
         }
+
+        bool aux2Changed()
+        {
+           return (_lastAux2State != _aux2State);
+        }
+
         
         virtual void pollForFrame(void) {}
         

--- a/src/receiver.hpp
+++ b/src/receiver.hpp
@@ -116,6 +116,7 @@ namespace hf {
         // maximum number of channels that any receiver will send (of which we'll use six)
         static const uint8_t MAXCHAN = 8;
 
+        uint8_t _lastAux1State;
         uint8_t _aux1State;
         uint8_t _aux2State;
 
@@ -239,6 +240,7 @@ namespace hf {
             demands.throttle = throttleFun(rawvals[_channelMap[CHANNEL_THROTTLE]]);
             
             // Store auxiliary switch state
+            _lastAux1State = _aux1State;
             _aux1State = getRawval(CHANNEL_AUX1) >= 0.0 ? (getRawval(CHANNEL_AUX1) > .4 ? 2 : 1) : 0;
             _aux2State = getRawval(CHANNEL_AUX2) >= 0.4 ? 1 : 0;
 
@@ -292,6 +294,11 @@ namespace hf {
         void setCalibrationStatus(bool calibrated)
         {
             _calibrated = calibrated;
+        }
+        
+        bool aux1Changed()
+        {
+           return (_lastAux1State != _aux1State);
         }
         
         virtual void pollForFrame(void) {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR supersedes PR #117 

Linked issues: #114 #115 #83 #63 #74 #85 
Included PRs: #116 #118 #119 #120 

Add a planner to Hackflight that enables the execution of pre-programed flight missions or individual actions.

## Current behavior before PR

There wasn't support for executing flight missions .

## Desired behavior after PR is merged

Flight missions are properly loaded and executed and individual actions can be performed.

